### PR TITLE
feat: 重构 MCP 客户端支持 SSE/Streamable HTTP，优化会话历史加载和附件处理

### DIFF
--- a/app/src/main/java/com/alian/assistant/MainActivity.kt
+++ b/app/src/main/java/com/alian/assistant/MainActivity.kt
@@ -71,6 +71,7 @@ import com.alian.assistant.presentation.ui.screens.SettingsScreen
 import com.alian.assistant.presentation.viewmodel.AlianViewModel
 import com.alian.assistant.presentation.ui.screens.settings.VoiceSelectionScreen
 import com.alian.assistant.presentation.ui.screens.settings.SpeechProviderSettingsScreen
+import com.alian.assistant.presentation.ui.screens.settings.SettingsSubScreen
 import com.alian.assistant.data.model.SpeechProvider
 import com.alian.assistant.data.model.SpeechProviderCredentials
 import com.alian.assistant.data.model.SpeechModels
@@ -617,6 +618,7 @@ class MainActivity : ComponentActivity() {
     @Composable
     fun MainApp() {
         var currentScreen by remember { mutableStateOf<Screen>(Screen.Alian) }
+        var settingsInitialSubScreen by remember { mutableStateOf<SettingsSubScreen?>(null) }
         var selectedRecord by remember { mutableStateOf<ExecutionRecord?>(null) }
         var currentChatHistory by remember {
             mutableStateOf<List<com.alian.assistant.data.ChatMessageData>>(
@@ -1276,7 +1278,12 @@ class MainActivity : ComponentActivity() {
                                 onNavigateToFlowTemplate = {
                                     currentScreen = Screen.FlowTemplate
                                 },
+                                initialSubScreen = settingsInitialSubScreen,
+                                onInitialSubScreenConsumed = {
+                                    settingsInitialSubScreen = null
+                                },
                                 onBack = {
+                                    settingsInitialSubScreen = null
                                     currentScreen = Screen.Alian
                                     showAlianLoginScreen = false
                                 },
@@ -1287,7 +1294,10 @@ class MainActivity : ComponentActivity() {
 
                             Screen.VoiceSelection -> VoiceSelectionScreen(
                                 currentVoice = settings.ttsVoice,
-                                onBack = { currentScreen = Screen.Settings },
+                                onBack = {
+                                    settingsInitialSubScreen = SettingsSubScreen.ALIAN
+                                    currentScreen = Screen.Settings
+                                },
                                 onSelectVoice = { voiceParam, auditionUrl ->
                                     settingsManager.updateTTSVoice(voiceParam)
                                 },

--- a/app/src/main/java/com/alian/assistant/core/mcp/MCPClient.kt
+++ b/app/src/main/java/com/alian/assistant/core/mcp/MCPClient.kt
@@ -5,72 +5,92 @@ import com.alian.assistant.core.mcp.models.MCPMethod
 import com.alian.assistant.core.mcp.models.MCPServerConfig
 import com.alian.assistant.core.mcp.models.MCPToolDefinition
 import com.alian.assistant.core.mcp.models.MCPTransport
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import okhttp3.sse.EventSources
 import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * MCP 客户端
- * 支持 WebSocket 和 HTTP 两种传输协议
+ * 支持 WebSocket、Streamable HTTP、SSE 三种传输协议
  */
 class MCPClient(private val config: MCPServerConfig) {
-    
+
     companion object {
         private const val TAG = "MCPClient"
         private const val CONNECT_TIMEOUT = 30_000L
         private const val READ_TIMEOUT = 60_000L
         private const val WRITE_TIMEOUT = 30_000L
+        private const val RESPONSE_TIMEOUT = 60_000L
         // MCP 协议版本（最新稳定版本）
         private const val PROTOCOL_VERSION = "2025-03-26"
     }
-    
+
     // 连接状态
     private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
     val connectionState: StateFlow<ConnectionState> = _connectionState
 
     // 是否已完成 MCP 初始化
     private var isInitialized = false
-    
+
     // 获取服务器配置
     val serverConfig: MCPServerConfig get() = config
-    
+
     // 是否已初始化完成
     fun isReady(): Boolean = isInitialized && _connectionState.value == ConnectionState.CONNECTED
-    
+
     // HTTP 客户端
     private val httpClient = OkHttpClient.Builder()
         .connectTimeout(CONNECT_TIMEOUT, TimeUnit.MILLISECONDS)
         .readTimeout(READ_TIMEOUT, TimeUnit.MILLISECONDS)
         .writeTimeout(WRITE_TIMEOUT, TimeUnit.MILLISECONDS)
         .build()
-    
+
     // WebSocket 客户端
     private val wsClient = OkHttpClient.Builder()
         .connectTimeout(CONNECT_TIMEOUT, TimeUnit.MILLISECONDS)
         .readTimeout(READ_TIMEOUT, TimeUnit.MILLISECONDS)
         .writeTimeout(WRITE_TIMEOUT, TimeUnit.MILLISECONDS)
         .build()
-    
+
+    // SSE 工厂（okhttp-sse）
+    private val sseFactory = EventSources.createFactory(httpClient)
+
     // WebSocket 连接
     private var webSocket: WebSocket? = null
-    
+
+    // SSE 连接
+    private var sseEventSource: EventSource? = null
+
     // 请求 ID 计数器
     private val requestId = AtomicInteger(0)
-    
-    // 待处理的请求（用于 WebSocket）
-    private val pendingRequests = mutableMapOf<Int, PendingRequest>()
 
-    // MCP Session ID（用于 HTTP 传输）
+    // 待处理的请求（用于 WebSocket/SSE）
+    private val pendingRequests = ConcurrentHashMap<Int, PendingRequest>()
+
+    // MCP Session ID（用于 HTTP/SSE 传输）
     private var sessionId: String? = null
-    
+
+    // 是否主动断开连接
+    @Volatile
+    private var isDisconnecting = false
+
     /**
      * 连接状态
      */
@@ -80,7 +100,7 @@ class MCPClient(private val config: MCPServerConfig) {
         CONNECTED,
         ERROR
     }
-    
+
     /**
      * 待处理的请求
      */
@@ -88,18 +108,22 @@ class MCPClient(private val config: MCPServerConfig) {
         val onResponse: (MCPMessage.Response) -> Unit,
         val onError: (Exception) -> Unit
     )
-    
+
     /**
      * 连接到 MCP Server
      */
-    suspend fun connect(): Result<Unit> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+    suspend fun connect(): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             _connectionState.value = ConnectionState.CONNECTING
 
-            when (config.transport) {
+            val connectResult = when (config.transport) {
                 MCPTransport.WEBSOCKET -> connectWebSocket()
-                MCPTransport.HTTP -> connectHTTP()
+                MCPTransport.STREAMABLE_HTTP -> connectHTTP()
                 MCPTransport.SSE -> connectSSE()
+            }
+
+            if (connectResult.isFailure) {
+                throw connectResult.exceptionOrNull() ?: Exception("Failed to connect")
             }
 
             _connectionState.value = ConnectionState.CONNECTED
@@ -111,11 +135,13 @@ class MCPClient(private val config: MCPServerConfig) {
             Result.failure(e)
         }
     }
-    
+
     /**
      * WebSocket 连接
      */
-    private fun connectWebSocket(): Result<Unit> {
+    private suspend fun connectWebSocket(): Result<Unit> = withContext(Dispatchers.IO) {
+        val openSignal = CompletableDeferred<Unit>()
+
         val request = Request.Builder()
             .url(config.url)
             .apply {
@@ -124,115 +150,169 @@ class MCPClient(private val config: MCPServerConfig) {
                 }
             }
             .build()
-        
+
         val listener = object : WebSocketListener() {
-            override fun onOpen(ws: WebSocket, response: okhttp3.Response) {
+            override fun onOpen(ws: WebSocket, response: Response) {
                 android.util.Log.d(TAG, "WebSocket opened: ${config.url}")
                 _connectionState.value = ConnectionState.CONNECTED
-            }
-            
-            override fun onMessage(ws: WebSocket, text: String) {
-                try {
-                    val json = JSONObject(text)
-                    val id = json.optInt("id", -1)
-                    
-                    if (id != -1) {
-                        val response = MCPMessage.Response.fromJson(json)
-                        pendingRequests.remove(id)?.let { pending ->
-                            if (response.isError) {
-                                pending.onError(Exception(response.error?.toString() ?: "Unknown error"))
-                            } else {
-                                pending.onResponse(response)
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    android.util.Log.e(TAG, "Failed to parse WebSocket message", e)
+                if (!openSignal.isCompleted) {
+                    openSignal.complete(Unit)
                 }
             }
-            
+
+            override fun onMessage(ws: WebSocket, text: String) {
+                handleJsonRpcPayload(text)
+            }
+
             override fun onClosing(ws: WebSocket, code: Int, reason: String) {
                 android.util.Log.d(TAG, "WebSocket closing: $code - $reason")
             }
-            
-            override fun onFailure(ws: WebSocket, t: Throwable, response: okhttp3.Response?) {
-                android.util.Log.e(TAG, "WebSocket failure", t)
-                _connectionState.value = ConnectionState.ERROR
-                
-                // 通知所有待处理的请求失败
-                pendingRequests.values.forEach { pending ->
-                    pending.onError(Exception(t.message ?: "WebSocket connection failed"))
+
+            override fun onClosed(ws: WebSocket, code: Int, reason: String) {
+                if (!isDisconnecting) {
+                    _connectionState.value = ConnectionState.DISCONNECTED
                 }
-                pendingRequests.clear()
+                android.util.Log.d(TAG, "WebSocket closed: $code - $reason")
+            }
+
+            override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
+                val error = Exception(t.message ?: "WebSocket connection failed", t)
+                android.util.Log.e(TAG, "WebSocket failure", t)
+                if (!openSignal.isCompleted) {
+                    openSignal.completeExceptionally(error)
+                }
+                _connectionState.value = ConnectionState.ERROR
+                failPendingRequests(error)
             }
         }
-        
-        webSocket = wsClient.newWebSocket(request, listener)
-        return Result.success(Unit)
+
+        return@withContext try {
+            isDisconnecting = false
+            webSocket = wsClient.newWebSocket(request, listener)
+            withTimeout(CONNECT_TIMEOUT) { openSignal.await() }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            webSocket?.close(1000, "connect failed")
+            webSocket = null
+            Result.failure(e)
+        }
     }
-    
+
     /**
-     * HTTP 连接（验证连接）
+     * Streamable HTTP 连接（不需要保持长连接）
      */
     private fun connectHTTP(): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    /**
+     * SSE 连接（Server-Sent Events）
+     * 建立长期事件流通道，用于接收异步 JSON-RPC 响应
+     */
+    private suspend fun connectSSE(): Result<Unit> = withContext(Dispatchers.IO) {
+        val openSignal = CompletableDeferred<Unit>()
+
+        sseEventSource?.cancel()
+        sseEventSource = null
+
         val request = Request.Builder()
-            .url("${config.url}/health")  // 假设有健康检查端点
+            .url(config.url)
             .apply {
                 config.getRequestHeaders().forEach { (key, value) ->
                     addHeader(key, value)
                 }
+                addHeader("Accept", "text/event-stream")
+                addHeader("Cache-Control", "no-cache")
+                sessionId?.let { addHeader("mcp-session-id", it) }
             }
             .get()
             .build()
-        
-        try {
-            val response = httpClient.newCall(request).execute()
-            if (response.isSuccessful) {
-                return Result.success(Unit)
-            } else {
-                // 如果没有健康检查端点，假设连接成功
-                return Result.success(Unit)
+
+        val listener = object : EventSourceListener() {
+            override fun onOpen(eventSource: EventSource, response: Response) {
+                android.util.Log.d(TAG, "SSE opened: ${config.url}")
+                _connectionState.value = ConnectionState.CONNECTED
+                if (!openSignal.isCompleted) {
+                    openSignal.complete(Unit)
+                }
             }
+
+            override fun onEvent(
+                eventSource: EventSource,
+                id: String?,
+                type: String?,
+                data: String
+            ) {
+                handleSSEPayload(data)
+            }
+
+            override fun onClosed(eventSource: EventSource) {
+                if (!isDisconnecting) {
+                    _connectionState.value = ConnectionState.DISCONNECTED
+                }
+                android.util.Log.d(TAG, "SSE closed: ${config.url}")
+            }
+
+            override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
+                val message = buildString {
+                    append(t?.message ?: "SSE connection failed")
+                    if (response != null) {
+                        append(" (HTTP ")
+                        append(response.code)
+                        append(")")
+                    }
+                }
+                val error = Exception(message, t)
+                android.util.Log.e(TAG, "SSE failure", error)
+                if (!openSignal.isCompleted) {
+                    openSignal.completeExceptionally(error)
+                }
+                if (!isDisconnecting) {
+                    _connectionState.value = ConnectionState.ERROR
+                }
+                failPendingRequests(error)
+            }
+        }
+
+        return@withContext try {
+            isDisconnecting = false
+            sseEventSource = sseFactory.newEventSource(request, listener)
+            withTimeout(CONNECT_TIMEOUT) { openSignal.await() }
+            Result.success(Unit)
         } catch (e: Exception) {
-            // 即使健康检查失败，也假设连接成功（因为可能是端点不存在）
-            return Result.success(Unit)
+            sseEventSource?.cancel()
+            sseEventSource = null
+            Result.failure(e)
         }
     }
-    
-    /**
-     * SSE 连接（Server-Sent Events）
-     * SSE 使用 HTTP POST 请求，但响应是事件流
-     */
-    private fun connectSSE(): Result<Unit> {
-        // SSE 连接不需要预连接，在发送请求时建立
-        // 这里只是验证连接是否可用
-        return Result.success(Unit)
-    }
-    
+
     /**
      * 断开连接
      */
     fun disconnect() {
+        isDisconnecting = true
         webSocket?.close(1000, "Normal closure")
         webSocket = null
-        pendingRequests.clear()
-        sessionId = null  // 清除 session ID
-        isInitialized = false  // 重置初始化状态
+        sseEventSource?.cancel()
+        sseEventSource = null
+        failPendingRequests(Exception("Connection closed"))
+        sessionId = null // 清除 session ID
+        isInitialized = false // 重置初始化状态
         _connectionState.value = ConnectionState.DISCONNECTED
         android.util.Log.d(TAG, "Disconnected from MCP Server: ${config.name}")
     }
-    
+
     /**
      * 发送请求（通用方法）
      */
     suspend fun sendRequest(
         method: String,
         params: JSONObject = JSONObject()
-    ): Result<Any?> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+    ): Result<Any?> = withContext(Dispatchers.IO) {
         try {
             when (config.transport) {
                 MCPTransport.WEBSOCKET -> sendWebSocketRequest(method, params)
-                MCPTransport.HTTP -> sendHTTPRequest(method, params)
+                MCPTransport.STREAMABLE_HTTP -> sendHTTPRequest(method, params)
                 MCPTransport.SSE -> sendSSERequest(method, params)
             }
         } catch (e: Exception) {
@@ -240,34 +320,36 @@ class MCPClient(private val config: MCPServerConfig) {
             Result.failure(e)
         }
     }
-    
+
     /**
      * 发送 WebSocket 请求
      */
     private suspend fun sendWebSocketRequest(
         method: String,
         params: JSONObject
-    ): Result<Any?> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+    ): Result<Any?> = withContext(Dispatchers.IO) {
         val id = requestId.incrementAndGet()
         val request = MCPMessage.Request(
             id = id,
             method = method,
             params = params
         )
-        
+
         return@withContext try {
-            val completable = kotlinx.coroutines.CompletableDeferred<MCPMessage.Response>()
-            
+            val completable = CompletableDeferred<MCPMessage.Response>()
+
             pendingRequests[id] = PendingRequest(
                 onResponse = { completable.complete(it) },
                 onError = { completable.completeExceptionally(it) }
             )
-            
-            webSocket?.send(request.toJson().toString())
-                ?: throw Exception("WebSocket not connected")
-            
-            val response = completable.await()
-            
+
+            val sent = webSocket?.send(request.toJson().toString()) ?: false
+            if (!sent) {
+                pendingRequests.remove(id)
+                throw Exception("WebSocket not connected")
+            }
+
+            val response = withTimeout(RESPONSE_TIMEOUT) { completable.await() }
             if (response.isError) {
                 Result.failure(Exception(response.error?.toString() ?: "Unknown error"))
             } else {
@@ -278,33 +360,33 @@ class MCPClient(private val config: MCPServerConfig) {
             Result.failure(e)
         }
     }
-    
+
     /**
-     * 发送 HTTP 请求
+     * 发送 Streamable HTTP 请求
      */
     private suspend fun sendHTTPRequest(
         method: String,
         params: JSONObject
-    ): Result<Any?> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+    ): Result<Any?> = withContext(Dispatchers.IO) {
         val id = requestId.incrementAndGet()
         val request = MCPMessage.Request(
             id = id,
             method = method,
             params = params
         )
-        
+
         val requestBody = request.toJson().toString()
         android.util.Log.d(TAG, "Sending $method request: $requestBody")
-        
+
         val requestBodyTyped = requestBody.toRequestBody("application/json".toMediaType())
-        
+
         val requestBuilder = Request.Builder()
             .url(config.url)
             .apply {
                 config.getRequestHeaders().forEach { (key, value) ->
                     addHeader(key, value)
                 }
-                // 添加 Accept header（MCP Server 要求同时接受 json 和 event-stream）
+                // MCP Server 要求同时接受 json 和 event-stream
                 addHeader("Accept", "application/json, text/event-stream")
                 // 添加 mcp-session-id header（如果是初始化请求，则不添加）
                 if (method != MCPMethod.INITIALIZE && sessionId != null) {
@@ -312,28 +394,26 @@ class MCPClient(private val config: MCPServerConfig) {
                 }
             }
             .post(requestBodyTyped)
-        
-        try {
+
+        return@withContext try {
             val response = httpClient.newCall(requestBuilder.build()).execute()
-            val responseBody = response.body?.string()
-            
-             try {
+            try {
                 if (!response.isSuccessful) {
                     return@withContext Result.failure(
-                        Exception("HTTP error: ${response.code} - $responseBody")
+                        Exception("HTTP error: ${response.code} - ${response.body?.string()}")
                     )
                 }
-                
-                // 从响应头中提取 mcp-session-id（初始化响应）
-                val responseSessionId = response.header("mcp-session-id")
-                if (responseSessionId != null) {
-                    sessionId = responseSessionId
-                    android.util.Log.d(TAG, "Received mcp-session-id: $responseSessionId")
+
+                updateSessionIdFromHeaders(response)
+
+                val responseBody = response.body?.string().orEmpty()
+                if (responseBody.isBlank()) {
+                    return@withContext Result.success(null)
                 }
-                
-                val json = JSONObject(responseBody ?: "")
+
+                val json = JSONObject(responseBody)
                 val mcpResponse = MCPMessage.Response.fromJson(json)
-                
+
                 if (mcpResponse.isError) {
                     Result.failure(Exception(mcpResponse.error?.toString() ?: "Unknown error"))
                 } else {
@@ -346,165 +426,205 @@ class MCPClient(private val config: MCPServerConfig) {
             Result.failure(e)
         }
     }
-    
+
     /**
-     * 发送 SSE 请求（Server-Sent Events）
-     * SSE 使用 HTTP POST 请求，响应是事件流格式
-     * 如果 POST 返回 405，则回退到 GET 方法
+     * 发送 SSE 请求
+     * 发送走 HTTP POST，响应优先从 SSE 事件流按 id 回传。
      */
     private suspend fun sendSSERequest(
         method: String,
         params: JSONObject
-    ): Result<Any?> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+    ): Result<Any?> = withContext(Dispatchers.IO) {
+        // 确保 SSE 事件流已连接
+        if (sseEventSource == null || _connectionState.value != ConnectionState.CONNECTED) {
+            val connectResult = connectSSE()
+            if (connectResult.isFailure) {
+                return@withContext Result.failure(
+                    connectResult.exceptionOrNull() ?: Exception("Failed to connect SSE stream")
+                )
+            }
+            _connectionState.value = ConnectionState.CONNECTED
+        }
+
         val id = requestId.incrementAndGet()
         val request = MCPMessage.Request(
             id = id,
             method = method,
             params = params
         )
-        
         val requestBody = request.toJson().toString()
         android.util.Log.d(TAG, "Sending SSE $method request: $requestBody")
-        
-        // 先尝试 POST 请求
-        val postResult = trySendSSERequest("POST", requestBody)
-        
-        // 如果 POST 返回 405，则尝试 GET 请求
-        if (postResult.isFailure) {
-            val exception = postResult.exceptionOrNull()
-            if (exception?.message?.contains("405") == true) {
-                android.util.Log.d(TAG, "POST returned 405, trying GET method")
-                return@withContext trySendSSERequest("GET", requestBody)
-            }
-        }
-        
-        postResult
-    }
-    
-    /**
-     * 尝试发送 SSE 请求（内部方法，支持指定 HTTP 方法）
-     */
-    private suspend fun trySendSSERequest(
-        httpMethod: String,
-        requestBody: String
-    ): Result<Any?> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+
+        val completable = CompletableDeferred<MCPMessage.Response>()
+        pendingRequests[id] = PendingRequest(
+            onResponse = { completable.complete(it) },
+            onError = { completable.completeExceptionally(it) }
+        )
+
         val requestBuilder = Request.Builder()
             .url(config.url)
             .apply {
                 config.getRequestHeaders().forEach { (key, value) ->
                     addHeader(key, value)
                 }
-                // SSE 需要 Accept: text/event-stream
-                addHeader("Accept", "text/event-stream")
-                
-                // POST 请求需要 Content-Type 和请求体
-                if (httpMethod == "POST") {
-                    addHeader("Content-Type", "application/json")
-                    val requestBodyTyped = requestBody.toRequestBody("application/json".toMediaType())
-                    post(requestBodyTyped)
-                } else {
-                    // GET 请求不需要请求体，将参数放在 URL 查询字符串中
-                    get()
+                addHeader("Accept", "application/json, text/event-stream")
+                addHeader("Content-Type", "application/json")
+                if (method != MCPMethod.INITIALIZE && sessionId != null) {
+                    addHeader("mcp-session-id", sessionId!!)
                 }
             }
-        
-        try {
+            .post(requestBody.toRequestBody("application/json".toMediaType()))
+
+        return@withContext try {
             val response = httpClient.newCall(requestBuilder.build()).execute()
-            
             try {
                 if (!response.isSuccessful) {
-                    val responseBody = response.body?.string()
+                    pendingRequests.remove(id)
                     return@withContext Result.failure(
-                        Exception("HTTP error: ${response.code} - $responseBody")
+                        Exception("HTTP error: ${response.code} - ${response.body?.string()}")
                     )
                 }
-                
-                // 从响应头中提取 mcp-session-id（初始化响应）
-                val responseSessionId = response.header("mcp-session-id")
-                if (responseSessionId != null) {
-                    sessionId = responseSessionId
-                    android.util.Log.d(TAG, "Received mcp-session-id: $responseSessionId")
+
+                val previousSessionId = sessionId
+                updateSessionIdFromHeaders(response)
+                if (method == MCPMethod.INITIALIZE && sessionId != null && sessionId != previousSessionId) {
+                    // initialize 后如果拿到了新的 session id，重建 SSE 连接让后续事件带上会话上下文
+                    val reconnectResult = connectSSE()
+                    if (reconnectResult.isFailure) {
+                        android.util.Log.w(
+                            TAG,
+                            "Failed to reconnect SSE with session id: ${reconnectResult.exceptionOrNull()?.message}"
+                        )
+                    }
                 }
-                
-                // SSE 响应是事件流，需要解析
-                val responseBody = response.body?.string() ?: ""
-                
-                // SSE 格式: data: {json}\n\n
-                val events = parseSSEEvents(responseBody)
-                
-                if (events.isEmpty()) {
-                    return@withContext Result.failure(Exception("No SSE events received"))
-                }
-                
-                // 取最后一个事件作为结果
-                val lastEvent = events.last()
-                val json = JSONObject(lastEvent)
-                val mcpResponse = MCPMessage.Response.fromJson(json)
-                
-                if (mcpResponse.isError) {
-                    Result.failure(Exception(mcpResponse.error?.toString() ?: "Unknown error"))
-                } else {
-                    Result.success(mcpResponse.result)
+
+                // 兼容部分服务端：POST 直接返回 JSON 或 event-stream
+                val responseBody = response.body?.string().orEmpty()
+                if (responseBody.isNotBlank()) {
+                    if (responseBody.trimStart().startsWith("{")) {
+                        handleJsonRpcPayload(responseBody)
+                    } else {
+                        parseSSEEvents(responseBody).forEach { payload ->
+                            handleSSEPayload(payload)
+                        }
+                    }
                 }
             } finally {
                 response.close()
             }
+
+            val mcpResponse = withTimeout(RESPONSE_TIMEOUT) { completable.await() }
+            if (mcpResponse.isError) {
+                Result.failure(Exception(mcpResponse.error?.toString() ?: "Unknown error"))
+            } else {
+                Result.success(mcpResponse.result)
+            }
         } catch (e: Exception) {
+            pendingRequests.remove(id)
             Result.failure(e)
         }
     }
-    
+
+    private fun handleSSEPayload(payload: String) {
+        val trimmed = payload.trim()
+        if (trimmed.isEmpty() || trimmed == "[DONE]") {
+            return
+        }
+        handleJsonRpcPayload(trimmed)
+    }
+
+    private fun handleJsonRpcPayload(payload: String) {
+        try {
+            val json = JSONObject(payload)
+            val id = json.optInt("id", -1)
+            if (id == -1) {
+                // 通知类消息无 id，当前客户端无需处理
+                return
+            }
+
+            val response = MCPMessage.Response.fromJson(json)
+            val pending = pendingRequests.remove(id) ?: return
+            if (response.isError) {
+                pending.onError(Exception(response.error?.toString() ?: "Unknown error"))
+            } else {
+                pending.onResponse(response)
+            }
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "Failed to parse JSON-RPC payload: $payload", e)
+        }
+    }
+
+    private fun failPendingRequests(exception: Exception) {
+        pendingRequests.values.forEach { pending ->
+            pending.onError(exception)
+        }
+        pendingRequests.clear()
+    }
+
+    private fun updateSessionIdFromHeaders(response: Response) {
+        val responseSessionId = response.header("mcp-session-id")
+        if (!responseSessionId.isNullOrBlank()) {
+            sessionId = responseSessionId
+            android.util.Log.d(TAG, "Received mcp-session-id: $responseSessionId")
+        }
+    }
+
     /**
-     * 解析 SSE 事件流
-     * SSE 格式: data: {json}\n\n
+     * 解析 SSE 事件流文本
+     * SSE 格式:
+     * event: message
+     * data: {...}
+     *
      */
     private fun parseSSEEvents(sseResponse: String): List<String> {
         val events = mutableListOf<String>()
         val lines = sseResponse.split("\n")
-        var currentData = StringBuilder()
-        
+        val dataBuffer = StringBuilder()
+
         for (line in lines) {
-            if (line.startsWith("data: ")) {
-                val data = line.substring(6).trim()
-                if (data.isNotEmpty()) {
-                    currentData.append(data)
+            when {
+                line.startsWith("data:") -> {
+                    dataBuffer.append(line.substringAfter("data:").trimStart())
+                    dataBuffer.append('\n')
                 }
-            } else if (line.isEmpty() && currentData.isNotEmpty()) {
-                // 空行表示事件结束
-                events.add(currentData.toString())
-                currentData.clear()
+
+                line.isBlank() -> {
+                    if (dataBuffer.isNotEmpty()) {
+                        events.add(dataBuffer.toString().trimEnd())
+                        dataBuffer.clear()
+                    }
+                }
             }
         }
-        
-        // 处理最后一个事件（如果没有以空行结尾）
-        if (currentData.isNotEmpty()) {
-            events.add(currentData.toString())
+
+        if (dataBuffer.isNotEmpty()) {
+            events.add(dataBuffer.toString().trimEnd())
         }
-        
+
         return events
     }
-    
+
     /**
      * 获取工具列表
      */
     suspend fun listTools(): Result<List<MCPToolDefinition>> {
         return try {
             val result = sendRequest(MCPMethod.TOOLS_LIST)
-            
+
             if (result.isFailure) {
                 return Result.failure(result.exceptionOrNull() ?: Exception("Unknown error"))
             }
-            
+
             val data = result.getOrNull()
             if (data !is JSONObject) {
                 return Result.failure(Exception("Invalid response format"))
             }
-            
+
             val toolsArray = data.optJSONArray("tools")
             if (toolsArray == null) {
                 return Result.success(emptyList())
             }
-            
+
             val tools = mutableListOf<MCPToolDefinition>()
             for (i in 0 until toolsArray.length()) {
                 val toolJson = toolsArray.getJSONObject(i)
@@ -516,7 +636,7 @@ class MCPClient(private val config: MCPServerConfig) {
                 )
                 tools.add(tool)
             }
-            
+
             android.util.Log.d(TAG, "Listed ${tools.size} tools from ${config.name}")
             Result.success(tools)
         } catch (e: Exception) {
@@ -524,7 +644,7 @@ class MCPClient(private val config: MCPServerConfig) {
             Result.failure(e)
         }
     }
-    
+
     /**
      * 调用工具
      */
@@ -537,13 +657,13 @@ class MCPClient(private val config: MCPServerConfig) {
                 put("name", name)
                 put("arguments", JSONObject(arguments))
             }
-            
+
             val result = sendRequest(MCPMethod.TOOLS_CALL, params)
-            
+
             if (result.isFailure) {
                 return Result.failure(result.exceptionOrNull() ?: Exception("Unknown error"))
             }
-            
+
             android.util.Log.d(TAG, "Called tool '$name' from ${config.name}")
             result
         } catch (e: Exception) {
@@ -556,52 +676,68 @@ class MCPClient(private val config: MCPServerConfig) {
      * 发送初始化完成通知
      * MCP 协议要求：initialize 成功后必须发送 notifications/initialized 通知
      */
-    private suspend fun sendInitializedNotification(): Result<Unit> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+    private suspend fun sendInitializedNotification(): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             val notification = MCPMessage.Notification(
                 method = MCPMethod.NOTIFICATIONS_INITIALIZED,
                 params = JSONObject()
             )
-            
             val requestBody = notification.toJson().toString()
             android.util.Log.d(TAG, "Sending initialized notification: $requestBody")
-            
-            val requestBodyTyped = requestBody.toRequestBody("application/json".toMediaType())
-            
-            val requestBuilder = Request.Builder()
-                .url(config.url)
-                .apply {
-                    config.getRequestHeaders().forEach { (key, value) ->
-                        addHeader(key, value)
+
+            when (config.transport) {
+                MCPTransport.WEBSOCKET -> {
+                    val sent = webSocket?.send(requestBody) ?: false
+                    if (!sent) {
+                        return@withContext Result.failure(Exception("WebSocket not connected"))
                     }
-                    addHeader("Accept", "application/json, text/event-stream")
-                    // 通知也需要携带 session ID
-                    if (sessionId != null) {
-                        addHeader("mcp-session-id", sessionId!!)
+                    Result.success(Unit)
+                }
+
+                MCPTransport.STREAMABLE_HTTP,
+                MCPTransport.SSE -> {
+                    if (config.transport == MCPTransport.SSE && (sseEventSource == null || _connectionState.value != ConnectionState.CONNECTED)) {
+                        val connectResult = connectSSE()
+                        if (connectResult.isFailure) {
+                            return@withContext Result.failure(
+                                connectResult.exceptionOrNull() ?: Exception("Failed to connect SSE stream")
+                            )
+                        }
+                    }
+
+                    val requestBuilder = Request.Builder()
+                        .url(config.url)
+                        .apply {
+                            config.getRequestHeaders().forEach { (key, value) ->
+                                addHeader(key, value)
+                            }
+                            addHeader("Accept", "application/json, text/event-stream")
+                            if (sessionId != null) {
+                                addHeader("mcp-session-id", sessionId!!)
+                            }
+                        }
+                        .post(requestBody.toRequestBody("application/json".toMediaType()))
+
+                    val response = httpClient.newCall(requestBuilder.build()).execute()
+                    try {
+                        if (!response.isSuccessful) {
+                            return@withContext Result.failure(
+                                Exception("HTTP error: ${response.code} - ${response.body?.string()}")
+                            )
+                        }
+                        updateSessionIdFromHeaders(response)
+                        Result.success(Unit)
+                    } finally {
+                        response.close()
                     }
                 }
-                .post(requestBodyTyped)
-            
-            val response = httpClient.newCall(requestBuilder.build()).execute()
-            
-            try {
-                if (!response.isSuccessful) {
-                    return@withContext Result.failure(
-                        Exception("HTTP error: ${response.code} - ${response.body?.string()}")
-                    )
-                }
-                
-                android.util.Log.d(TAG, "Sent initialized notification successfully")
-                Result.success(Unit)
-            } finally {
-                response.close()
             }
         } catch (e: Exception) {
             android.util.Log.e(TAG, "Failed to send initialized notification", e)
             Result.failure(e)
         }
     }
-    
+
     /**
      * 初始化 MCP 连接
      */
@@ -617,19 +753,23 @@ class MCPClient(private val config: MCPServerConfig) {
                     put("version", "1.0.0")
                 })
             }
-            
+
             val result = sendRequest(MCPMethod.INITIALIZE, params)
-            
+
             if (result.isFailure) {
                 return Result.failure(result.exceptionOrNull() ?: Exception("Unknown error"))
             }
-            
+
             // MCP 协议要求：initialize 成功后必须发送 notifications/initialized 通知
             val notifyResult = sendInitializedNotification()
             if (notifyResult.isFailure) {
-                android.util.Log.w(TAG, "Failed to send initialized notification, but continuing...", notifyResult.exceptionOrNull())
+                android.util.Log.w(
+                    TAG,
+                    "Failed to send initialized notification, but continuing...",
+                    notifyResult.exceptionOrNull()
+                )
             }
-            // 标记初始化完成
+
             isInitialized = true
             android.util.Log.d(TAG, "Initialized MCP connection: ${config.name}")
             Result.success(Unit)

--- a/app/src/main/java/com/alian/assistant/core/mcp/models/MCPServerConfig.kt
+++ b/app/src/main/java/com/alian/assistant/core/mcp/models/MCPServerConfig.kt
@@ -1,6 +1,7 @@
 package com.alian.assistant.core.mcp.models
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.json.JSONObject
@@ -81,12 +82,12 @@ data class MCPServerConfig(
             }
             
             // 支持 type 和 transport 两种字段名
-            val transportStr = json.optString("type", null) ?: json.optString("transport", "http")
-            val transport = when (transportStr.lowercase()) {
-                "websocket", "ws", "streamable_http" -> MCPTransport.HTTP
-                "sse" -> MCPTransport.SSE
-                else -> MCPTransport.HTTP
+            val transportStr = when {
+                json.has("transport") -> json.optString("transport", "")
+                json.has("type") -> json.optString("type", "")
+                else -> "streamable_http"
             }
+            val transport = MCPTransport.fromRaw(transportStr)
 
             val apiKey = json.optString("apiKey", null)?.takeIf { it.isNotBlank() }
 
@@ -155,7 +156,35 @@ data class MCPServerConfig(
  */
 @Serializable
 enum class MCPTransport {
-    WEBSOCKET,  // WebSocket 长连接
-    HTTP,       // HTTP 请求
-    SSE         // Server-Sent Events
+    @SerialName("websocket")
+    WEBSOCKET,         // WebSocket 长连接
+    @SerialName("streamable_http")
+    STREAMABLE_HTTP,   // Streamable HTTP
+    @SerialName("sse")
+    SSE;               // Server-Sent Events
+
+    val wireValue: String
+        get() = when (this) {
+            WEBSOCKET -> "websocket"
+            STREAMABLE_HTTP -> "streamable_http"
+            SSE -> "sse"
+        }
+
+    companion object {
+        fun fromRaw(raw: String?): MCPTransport {
+            val normalized = raw
+                ?.trim()
+                ?.lowercase()
+                ?.replace("-", "_")
+                ?: "streamable_http"
+
+            return when (normalized) {
+                "websocket", "ws" -> WEBSOCKET
+                "sse" -> SSE
+                // 兼容历史/别名
+                "streamable_http", "http", "https" -> STREAMABLE_HTTP
+                else -> STREAMABLE_HTTP
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/alian/assistant/data/repository/MCPRepository.kt
+++ b/app/src/main/java/com/alian/assistant/data/repository/MCPRepository.kt
@@ -183,7 +183,7 @@ class MCPRepository(context: Context) {
                 description = configObj.optString("description", null),
                 url = configObj.getString("url"),
                 transport = MCPServerConfig.fromJson(configJson).getOrNull()?.transport
-                    ?: MCPTransport.HTTP,
+                    ?: MCPTransport.STREAMABLE_HTTP,
                 enabled = configObj.getBoolean("enabled"),
                 apiKey = apiKey,
                 headers = configObj.optJSONObject("headers")?.let { headersObj ->
@@ -213,7 +213,9 @@ class MCPRepository(context: Context) {
                 put("name", config.name)
                 put("description", config.description)
                 put("url", config.url)
-                put("transport", config.transport.name)
+                // 同时保存 transport 和 type，兼容应用内字段与标准 MCP 配置字段
+                put("transport", config.transport.wireValue)
+                put("type", config.transport.wireValue)
                 put("enabled", config.enabled)
                 put("created_at", config.createdAt)
                 put("updated_at", config.updatedAt)

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/AlianChatScreen.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/AlianChatScreen.kt
@@ -3,6 +3,7 @@ package com.alian.assistant.presentation.ui.screens
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -194,11 +195,17 @@ fun AlianChatScreen(
         onHideBottomBarChanged(showVoiceCall)
     }
 
-    // 自动滚动到底部
-    LaunchedEffect(viewModel.unifiedChatTimeline.size) {
-        if (viewModel.unifiedChatTimeline.isNotEmpty()) {
-            listState.animateScrollToItem(viewModel.unifiedChatTimeline.size - 1)
+    // 自动滚动到底部（历史切换期间禁用动画滚动，避免大量消息恢复时卡顿）
+    val sessionLoadingState = viewModel.sessionLoadingState.value
+    LaunchedEffect(viewModel.unifiedChatTimeline.size, sessionLoadingState) {
+        if (viewModel.unifiedChatTimeline.isEmpty()) {
+            return@LaunchedEffect
         }
+        val lastIndex = viewModel.unifiedChatTimeline.size - 1
+        if (sessionLoadingState is com.alian.assistant.presentation.viewmodel.SessionLoadingState.Switching) {
+            return@LaunchedEffect
+        }
+        listState.scrollToItem(lastIndex)
     }
 
     val context = LocalContext.current
@@ -237,13 +244,10 @@ fun AlianChatScreen(
             AlianChatHistoryDrawer(
                 context = context,
                 sessions = viewModel.sessions.toList(),
+                selectedSessionId = viewModel.currentSessionIdUi.value,
                 onSessionClick = { session: SessionData ->
-                    scope.launch {
-                        val result = viewModel.selectSession(session.session_id)
-                        if (result.isSuccess) {
-                            drawerState.close()
-                        }
-                    }
+                    viewModel.selectSessionAsync(session.session_id)
+                    scope.launch { drawerState.close() }
                 },
                 onDeleteSession = { session: SessionData ->
                     scope.launch {
@@ -322,40 +326,61 @@ fun AlianChatScreen(
                             onStopClick = {
                                 viewModel.stopTTS()
                             },
-                            onLinkClick = { url, fileName ->
-                                // 检查是否为图片文件
-                                val isImage = listOf(".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp").any {
-                                    fileName.lowercase().endsWith(it)
-                                }
-                                
-                                // 检查是否为视频文件
-                                val isVideo = listOf(".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv", ".webm", ".m4v", ".3gp").any {
-                                    fileName.lowercase().endsWith(it)
-                                }
-                                
-                                Log.d("AlianChatScreen", "onLinkClick: url=$url, fileName=$fileName, isImage=$isImage, isVideo=$isVideo")
-                                
-                                when {
-                                    isImage -> {
-                                        // 图片文件使用独立的图片预览
-                                        imagePreviewUrl = url
-                                        imagePreviewTitle = fileName
-                                        showImagePreview = true
-                                        Log.d("AlianChatScreen", "打开图片预览: $url")
+                            onLinkClick = { url, fileName, fileId ->
+                                scope.launch {
+                                    var resolvedUrl = url
+                                    val isValidUrl = resolvedUrl.startsWith("http://") || resolvedUrl.startsWith("https://")
+
+                                    if (!isValidUrl && !fileId.isNullOrBlank()) {
+                                        val backendClient = viewModel.getBackendClient()
+                                        if (backendClient != null) {
+                                            val signedUrlResult = backendClient.getFileSignedUrl(fileId)
+                                            if (signedUrlResult.isSuccess) {
+                                                resolvedUrl = signedUrlResult.getOrNull().orEmpty()
+                                                Log.d("AlianChatScreen", "按需签名附件成功: fileId=$fileId")
+                                            } else {
+                                                Log.w("AlianChatScreen", "按需签名附件失败: fileId=$fileId, error=${signedUrlResult.exceptionOrNull()?.message}")
+                                            }
+                                        }
                                     }
-                                    isVideo -> {
-                                        // 视频文件使用独立的视频预览
-                                        videoPreviewUrl = url
-                                        videoPreviewTitle = fileName
-                                        showVideoPreview = true
-                                        Log.d("AlianChatScreen", "打开视频预览: $url")
+
+                                    val finalValidUrl = resolvedUrl.startsWith("http://") || resolvedUrl.startsWith("https://")
+                                    if (!finalValidUrl) {
+                                        Toast.makeText(context, "附件链接无效，无法获取可访问 URL", Toast.LENGTH_SHORT).show()
+                                        return@launch
                                     }
-                                    else -> {
-                                        // 其他文件使用 Markdown WebView
-                                        markdownWebViewUrl = url
-                                        markdownWebViewTitle = fileName
-                                        showMarkdownWebView = true
-                                        Log.d("AlianChatScreen", "打开 Markdown 预览: $url")
+
+                                    // 检查是否为图片文件
+                                    val isImage = listOf(".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp").any {
+                                        fileName.lowercase().endsWith(it)
+                                    }
+
+                                    // 检查是否为视频文件
+                                    val isVideo = listOf(".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv", ".webm", ".m4v", ".3gp").any {
+                                        fileName.lowercase().endsWith(it)
+                                    }
+
+                                    Log.d("AlianChatScreen", "onLinkClick: url=$resolvedUrl, fileName=$fileName, isImage=$isImage, isVideo=$isVideo, fileId=$fileId")
+
+                                    when {
+                                        isImage -> {
+                                            imagePreviewUrl = resolvedUrl
+                                            imagePreviewTitle = fileName
+                                            showImagePreview = true
+                                            Log.d("AlianChatScreen", "打开图片预览: $resolvedUrl")
+                                        }
+                                        isVideo -> {
+                                            videoPreviewUrl = resolvedUrl
+                                            videoPreviewTitle = fileName
+                                            showVideoPreview = true
+                                            Log.d("AlianChatScreen", "打开视频预览: $resolvedUrl")
+                                        }
+                                        else -> {
+                                            markdownWebViewUrl = resolvedUrl
+                                            markdownWebViewTitle = fileName
+                                            showMarkdownWebView = true
+                                            Log.d("AlianChatScreen", "打开 Markdown 预览: $resolvedUrl")
+                                        }
                                     }
                                 }
                             },

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/SettingsScreen.kt
@@ -198,6 +198,8 @@ fun SettingsScreen(
     onNavigateToVoiceSelection: () -> Unit = {},
     onNavigateToSpeechProviderSettings: () -> Unit = {},
     onNavigateToFlowTemplate: () -> Unit = {},
+    initialSubScreen: SettingsSubScreen? = null,
+    onInitialSubScreenConsumed: () -> Unit = {},
     onBack: () -> Unit = {},
     mediaProjectionResultCode: Int? = null,
     mediaProjectionData: Intent? = null,
@@ -218,7 +220,16 @@ fun SettingsScreen(
     var showSuCommandWarningDialog by remember { mutableStateOf(false) }
 
     // 二级页面导航状态
-    var currentSubScreen by remember { mutableStateOf<SettingsSubScreen?>(null) }
+    var currentSubScreen by remember {
+        mutableStateOf<SettingsSubScreen?>(null)
+    }
+
+    LaunchedEffect(initialSubScreen) {
+        if (initialSubScreen != null) {
+            currentSubScreen = initialSubScreen
+            onInitialSubScreenConsumed()
+        }
+    }
 
     // 页面可见性状态（用于动画）
     var isPageVisible by remember { mutableStateOf(false) }
@@ -744,37 +755,11 @@ fun SettingsScreen(
                             CompactGridItem(
                                 icon = Icons.Default.HelpOutline,
                                 title = stringResource(R.string.settings_item_help),
+                                subtitle = stringResource(R.string.settings_item_help_subtitle),
                                 onClick = { currentSubScreen = SettingsSubScreen.HELP }
                             )
                         }
-                        // 反馈与调试
-                        Box(modifier = Modifier.weight(1f)) {
-                            CompactGridItem(
-                                icon = Icons.Default.Feedback,
-                                title = stringResource(R.string.settings_item_feedback),
-                                onClick = { currentSubScreen = SettingsSubScreen.FEEDBACK }
-                            )
-                        }
-                        // 关于
-                        Box(modifier = Modifier.weight(1f)) {
-                            CompactGridItem(
-                                icon = Icons.Default.Info,
-                                title = stringResource(R.string.settings_item_about),
-                                onClick = { currentSubScreen = SettingsSubScreen.ABOUT }
-                            )
-                        }
-                    }
-                }
-            }
-
-            item {
-                Box(modifier = Modifier.staggeredFadeIn(13)) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
+                        // 更新
                         Box(modifier = Modifier.weight(1f)) {
                             CompactGridItem(
                                 icon = Icons.Default.CloudSync,
@@ -783,8 +768,15 @@ fun SettingsScreen(
                                 onClick = { currentSubScreen = SettingsSubScreen.UPDATE }
                             )
                         }
-                        Box(modifier = Modifier.weight(1f)) {}
-                        Box(modifier = Modifier.weight(1f)) {}
+                        // 关于
+                        Box(modifier = Modifier.weight(1f)) {
+                            CompactGridItem(
+                                icon = Icons.Default.Info,
+                                title = stringResource(R.string.settings_item_about),
+                                subtitle = stringResource(R.string.settings_item_about_subtitle),
+                                onClick = { currentSubScreen = SettingsSubScreen.ABOUT }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/online/AlianChatHistoryDrawer.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/online/AlianChatHistoryDrawer.kt
@@ -80,6 +80,7 @@ fun glossyGradient(colors: BaoziColors): Brush {
 fun AlianChatHistoryDrawer(
     context: Context,
     sessions: List<SessionData>,
+    selectedSessionId: String? = null,
     onSessionClick: (SessionData) -> Unit,
     onDeleteSession: (SessionData) -> Unit,
     onCreateNewSession: () -> Unit,
@@ -343,6 +344,7 @@ fun AlianChatHistoryDrawer(
                         SessionDrawerItem(
                             context = context,
                             session = session,
+                            isSelected = session.session_id == selectedSessionId,
                             onClick = { onSessionClick(session) },
                             onDelete = { onDeleteSession(session) }
                         )

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/online/AlianChatMessageList.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/online/AlianChatMessageList.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -32,7 +33,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
@@ -61,6 +64,7 @@ import com.alian.assistant.presentation.viewmodel.AlianViewModel
 import com.alian.assistant.presentation.viewmodel.DeepThinkingItem
 import com.alian.assistant.presentation.viewmodel.MessageItem
 import com.alian.assistant.presentation.viewmodel.PlanItem
+import com.alian.assistant.presentation.viewmodel.SessionLoadingState
 import java.io.File
 
 /**
@@ -73,7 +77,7 @@ import java.io.File
  * @param currentPlayingMessageId 当前播放的消息 ID
  * @param onPlayClick 播放点击回调
  * @param onStopClick 停止点击回调
- * @param onLinkClick 链接点击回调
+ * @param onLinkClick 链接点击回调（url, fileName, fileId）
  * @param userAvatar 用户头像
  * @param assistantAvatar 艾莲头像
  */
@@ -84,10 +88,11 @@ fun AlianChatMessageList(
     listState: LazyListState,
     shouldPinPlanCard: Boolean,
     ttsEnabled: Boolean,
+    enableItemAnimations: Boolean,
     currentPlayingMessageId: State<String?>,
     onPlayClick: (String) -> Unit,
     onStopClick: () -> Unit,
-    onLinkClick: (String, String) -> Unit,
+    onLinkClick: (String, String, String?) -> Unit,
     userAvatar: String?,
     assistantAvatar: String?
 ) {
@@ -97,7 +102,10 @@ fun AlianChatMessageList(
     val timelineData by remember {
         derivedStateOf {
             val filtered = viewModel.unifiedChatTimeline.toList().filterNot { item ->
-                item is MessageItem && !item.message.isUser && item.message.content.isBlank()
+                item is MessageItem &&
+                    !item.message.isUser &&
+                    item.message.content.isBlank() &&
+                    item.message.attachments.isEmpty()
             }
             val plan = filtered.filterIsInstance<PlanItem>().firstOrNull()
             Pair(filtered, plan)
@@ -146,23 +154,7 @@ fun AlianChatMessageList(
 
             when (item) {
                 is MessageItem -> {
-                    var isVisible by remember { mutableStateOf(false) }
-                    LaunchedEffect(item.message.id) {
-                        isVisible = true
-                    }
-
-                    AnimatedVisibility(
-                        visible = isVisible,
-                        enter = slideInVertically(
-                            initialOffsetY = { 30 },
-                            animationSpec = spring(
-                                dampingRatio = Spring.DampingRatioMediumBouncy,
-                                stiffness = Spring.StiffnessLow
-                            )
-                        ) + fadeIn(
-                            animationSpec = tween(durationMillis = 300)
-                        )
-                    ) {
+                    if (!enableItemAnimations) {
                         ChatMessageBubble(
                             message = item.message,
                             ttsEnabled = ttsEnabled,
@@ -174,6 +166,36 @@ fun AlianChatMessageList(
                             userAvatar = userAvatar,
                             assistantAvatar = assistantAvatar
                         )
+                    } else {
+                        var isVisible by remember { mutableStateOf(false) }
+                        LaunchedEffect(item.message.id) {
+                            isVisible = true
+                        }
+
+                        AnimatedVisibility(
+                            visible = isVisible,
+                            enter = slideInVertically(
+                                initialOffsetY = { 30 },
+                                animationSpec = spring(
+                                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                                    stiffness = Spring.StiffnessLow
+                                )
+                            ) + fadeIn(
+                                animationSpec = tween(durationMillis = 300)
+                            )
+                        ) {
+                            ChatMessageBubble(
+                                message = item.message,
+                                ttsEnabled = ttsEnabled,
+                                isPlaying = currentPlayingMessageId.value == item.message.id,
+                                onPlayClick = onPlayClick,
+                                onStopClick = onStopClick,
+                                onLinkClick = onLinkClick,
+                                backendBaseUrl = viewModel.backendBaseUrl,
+                                userAvatar = userAvatar,
+                                assistantAvatar = assistantAvatar
+                            )
+                        }
                     }
                 }
 
@@ -422,7 +444,7 @@ val currentToolName = viewModel.currentToolName.value
  * @param ttsEnabled 是否启用 TTS
  * @param onPlayClick 播放点击回调
  * @param onStopClick 停止点击回调
- * @param onLinkClick 链接点击回调
+ * @param onLinkClick 链接点击回调（url, fileName, fileId）
  * @param userAvatar 用户头像
  * @param assistantAvatar 艾莲头像
  */
@@ -434,11 +456,22 @@ fun AlianChatContent(
     ttsEnabled: Boolean,
     onPlayClick: (String) -> Unit,
     onStopClick: () -> Unit,
-    onLinkClick: (String, String) -> Unit,
+    onLinkClick: (String, String, String?) -> Unit,
     userAvatar: String?,
     assistantAvatar: String?
 ) {
     val colors = BaoziTheme.colors
+    val sessionLoadingState = viewModel.sessionLoadingState.value
+    val hasRenderableItems = viewModel.unifiedChatTimeline.any { item ->
+        when (item) {
+            is MessageItem -> {
+                item.message.isUser ||
+                    item.message.content.isNotBlank() ||
+                    item.message.attachments.isNotEmpty()
+            }
+            else -> true
+        }
+    }
 
     // 状态通知文本
     val statusText = when {
@@ -466,34 +499,129 @@ fun AlianChatContent(
             }
         }
 
-        if (viewModel.messages.isEmpty()) {
-            // 空状态
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-            ) {
-                EmptyChatState(modifier = Modifier.fillMaxSize())
+        when (sessionLoadingState) {
+            is SessionLoadingState.Switching -> {
+                if (!hasRenderableItems) {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            CircularProgressIndicator(
+                                color = colors.primary,
+                                strokeWidth = 2.dp
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Text(
+                                text = "正在加载历史消息...",
+                                fontSize = 13.sp,
+                                color = colors.textSecondary
+                            )
+                        }
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(12.dp),
+                                color = colors.primary,
+                                strokeWidth = 1.5.dp
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "历史仍在补充加载中...",
+                                fontSize = 12.sp,
+                                color = colors.textHint
+                            )
+                        }
+
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth()
+                        ) {
+                            AlianChatMessageList(
+                                viewModel = viewModel,
+                                listState = listState,
+                                shouldPinPlanCard = shouldPinPlanCard,
+                                ttsEnabled = ttsEnabled,
+                                enableItemAnimations = false,
+                                currentPlayingMessageId = viewModel.currentPlayingMessageId,
+                                onPlayClick = onPlayClick,
+                                onStopClick = onStopClick,
+                                onLinkClick = onLinkClick,
+                                userAvatar = userAvatar,
+                                assistantAvatar = assistantAvatar
+                            )
+                        }
+                    }
+                }
             }
-        } else {
-            // 消息列表
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-            ) {
-                AlianChatMessageList(
-                    viewModel = viewModel,
-                    listState = listState,
-                    shouldPinPlanCard = shouldPinPlanCard,
-                    ttsEnabled = ttsEnabled,
-                    currentPlayingMessageId = viewModel.currentPlayingMessageId,
-                    onPlayClick = onPlayClick,
-                    onStopClick = onStopClick,
-                    onLinkClick = onLinkClick,
-                    userAvatar = userAvatar,
-                    assistantAvatar = assistantAvatar
-                )
+
+            is SessionLoadingState.Failed -> {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = sessionLoadingState.message,
+                            fontSize = 13.sp,
+                            color = colors.error
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.retryCurrentSessionLoad() }) {
+                            Text("重试", color = colors.primary)
+                        }
+                    }
+                }
+            }
+
+            else -> {
+                if (!hasRenderableItems) {
+                    // 空状态
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                    ) {
+                        EmptyChatState(modifier = Modifier.fillMaxSize())
+                    }
+                } else {
+                    // 消息列表
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                    ) {
+                        AlianChatMessageList(
+                            viewModel = viewModel,
+                            listState = listState,
+                            shouldPinPlanCard = shouldPinPlanCard,
+                            ttsEnabled = ttsEnabled,
+                            enableItemAnimations = true,
+                            currentPlayingMessageId = viewModel.currentPlayingMessageId,
+                            onPlayClick = onPlayClick,
+                            onStopClick = onStopClick,
+                            onLinkClick = onLinkClick,
+                            userAvatar = userAvatar,
+                            assistantAvatar = assistantAvatar
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/online/AlianComponents.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/online/AlianComponents.kt
@@ -1,6 +1,7 @@
 package com.alian.assistant.presentation.ui.screens.online
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -241,7 +242,7 @@ fun ChatMessageBubble(
     isPlaying: Boolean = false,
     onPlayClick: ((String) -> Unit)? = null,
     onStopClick: (() -> Unit)? = null,
-    onLinkClick: ((String, String) -> Unit)? = null,
+    onLinkClick: ((String, String, String?) -> Unit)? = null,
     backendBaseUrl: String = "",
     userAvatar: String? = null,
     assistantAvatar: String? = null
@@ -459,6 +460,7 @@ fun ChatMessageBubble(
                                             } else {
                                                 originalUrl
                                             }
+                                            val isValidUrl = url.startsWith("http://") || url.startsWith("https://")
                                             Log.d("ChatMessageBubble", "附件按钮: fileName=$fileName, originalUrl=$originalUrl, url=$url")
                                             
                                             // 检查是否为图片附件
@@ -477,13 +479,23 @@ fun ChatMessageBubble(
                                                 isVideo -> Icons.Default.Videocam
                                                 else -> Icons.Default.Visibility
                                             }
+                                            val clickContext = LocalContext.current
                                             
                                             Row(
                                                 modifier = Modifier
                                                     .fillMaxWidth()
                                                     .clickable {
-                                                        Log.d("ChatMessageBubble", "附件按钮被点击: url=$url, fileName=$fileName")
-                                                        onLinkClick(url, fileName)
+                                                        if (isValidUrl || !attachment.file_id.isNullOrBlank()) {
+                                                            Log.d("ChatMessageBubble", "附件按钮被点击: url=$url, fileName=$fileName, fileId=${attachment.file_id}")
+                                                            onLinkClick(url, fileName, attachment.file_id)
+                                                        } else {
+                                                            Toast.makeText(
+                                                                clickContext,
+                                                                "附件链接无效，缺少可访问 URL",
+                                                                Toast.LENGTH_SHORT
+                                                            ).show()
+                                                            Log.w("ChatMessageBubble", "附件URL无效: fileName=$fileName, url=$url, fileId=${attachment.file_id}")
+                                                        }
                                                     },
                                                 horizontalArrangement = Arrangement.Start,
                                                 verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/MCPSettingsContent.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/MCPSettingsContent.kt
@@ -415,7 +415,7 @@ private fun ServerCard(
                         label = "协议",
                         value = when (server.transport) {
                             MCPTransport.WEBSOCKET -> "WebSocket"
-                            MCPTransport.HTTP -> "HTTP"
+                            MCPTransport.STREAMABLE_HTTP -> "Streamable HTTP"
                             MCPTransport.SSE -> "SSE"
                         }
                     )
@@ -507,8 +507,8 @@ private fun AddMCPServerDialog(
                     },
                     placeholder = """{
   "name": "My Server",
-  "url": "wss://...",
-  "transport": "websocket",
+  "url": "https://your-mcp-server.example.com/mcp",
+  "transport": "streamable_http",
   "apiKey": "your-api-key"
 }""",
                     isError = displayError != null,
@@ -516,7 +516,7 @@ private fun AddMCPServerDialog(
                 )
 
                 Text(
-                    text = "💡 支持的认证方式：\n• apiKey: API 密钥（自动加密存储）\n• headers: 自定义请求头（如 Bearer Token）",
+                    text = "💡 支持的配置：\n• transport: streamable_http / sse / websocket\n• apiKey: API 密钥（自动加密存储）\n• headers: 自定义请求头（如 Bearer Token）",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontSize = 12.sp

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/UpdateSettingsSection.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/UpdateSettingsSection.kt
@@ -41,8 +41,8 @@ fun UpdateSettingsSection() {
             updateRepository = DefaultUpdateRepository(
                 settingsManager = SettingsManager(appContext),
                 releaseSourcePort = GithubReleaseSourceAdapter(
-                    owner = "xielingbo",
-                    repo = "beanbun",
+                    owner = "xlb1130",
+                    repo = "alian-android",
                 ),
                 downloadPort = SystemDownloadAdapter(appContext),
                 historyStore = UpdateHistoryStore(appContext),
@@ -92,6 +92,7 @@ fun UpdateSettingsSection() {
             },
         )
 
+/*
         val release = state.latestRelease
         if (release != null) {
             SettingsItem(
@@ -144,5 +145,6 @@ fun UpdateSettingsSection() {
         }
 
         Spacer(modifier = Modifier.height(32.dp))
+*/
     }
 }

--- a/app/src/main/java/com/alian/assistant/presentation/viewmodel/AlianViewModel.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/viewmodel/AlianViewModel.kt
@@ -47,15 +47,18 @@ import com.alian.assistant.core.alian.backend.UIStepEvent
 import com.alian.assistant.core.alian.backend.UIToolCall
 import com.alian.assistant.core.alian.backend.UIToolEvent
 import com.alian.assistant.infrastructure.ai.tts.CosyVoiceTTSClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.encodeToJsonElement
 
 /**
  * 聊天消息
@@ -125,6 +128,16 @@ sealed class AlianChatState {
 }
 
 /**
+ * 历史会话加载状态
+ */
+sealed class SessionLoadingState {
+    object Idle : SessionLoadingState()
+    data class Switching(val sessionId: String) : SessionLoadingState()
+    data class Loaded(val sessionId: String) : SessionLoadingState()
+    data class Failed(val sessionId: String, val message: String) : SessionLoadingState()
+}
+
+/**
  * Alian 对话 ViewModel
  */
 class AlianViewModel(private val context: Context) : ViewModel() {
@@ -182,6 +195,14 @@ class AlianViewModel(private val context: Context) : ViewModel() {
     private val _isLoadingSessions = mutableStateOf(false)
     val isLoadingSessions: State<Boolean> = _isLoadingSessions
 
+    // 当前聊天区会话切换状态（用于异步加载历史）
+    private val _sessionLoadingState = mutableStateOf<SessionLoadingState>(SessionLoadingState.Idle)
+    val sessionLoadingState: State<SessionLoadingState> = _sessionLoadingState
+
+    // 当前选中的会话（用于抽屉高亮）
+    private val _currentSessionIdUi = mutableStateOf<String?>(null)
+    val currentSessionIdUi: State<String?> = _currentSessionIdUi
+
     // API 模式
     var useBackend: Boolean = false
 
@@ -220,6 +241,16 @@ class AlianViewModel(private val context: Context) : ViewModel() {
 
     // 当前消息发送任务
     private var currentMessageJob: Job? = null
+
+    // 当前会话历史加载任务（点击历史时异步加载）
+    private var sessionLoadJob: Job? = null
+    private var sessionLoadToken: Long = 0L
+    private var lastRequestedSessionId: String? = null
+
+    // 每轮用户输入对应一个 Plan 气泡：记录当前轮的 Plan 锚点
+    private var activePlanBubbleEventId: String? = null
+    private var activePlanBubbleTimestamp: Long? = null
+    private var activePlanBoundaryUserMessageId: String? = null
 
     /**
      * 获取当前会话ID
@@ -442,11 +473,15 @@ class AlianViewModel(private val context: Context) : ViewModel() {
 
     fun addUserMessage(content: String) {
         if (content.isNotBlank()) {
+            // 新的一轮用户输入，重置 Plan 锚点
+            activePlanBubbleEventId = null
+            activePlanBubbleTimestamp = null
             val message = ChatMessage(
                 id = generateMessageId(),
                 content = content,
                 isUser = true
             )
+            activePlanBoundaryUserMessageId = message.id
             _messages.add(message)
             // 添加到统一时间线
             _unifiedChatTimeline.add(MessageItem(message))
@@ -596,13 +631,29 @@ class AlianViewModel(private val context: Context) : ViewModel() {
             }
             is UIMessageEvent -> {
                 // 普通消息事件
-                // 在 Backend 模式下，后端可能返回 message 类型的消息（包括 user 消息），直接作为 AI 消息显示
+                // 兼容 user/assistant 角色
                 if (event.content.isNotBlank()) {
-                    // 直接添加消息，附件通过 attachments 字段传递
-                    addAssistantMessage(
-                        event.content,
-                        event.attachments ?: emptyList()
-                    )
+                    if (event.role == "user") {
+                        val message = ChatMessage(
+                            id = generateMessageId(),
+                            content = event.content,
+                            isUser = true,
+                            timestamp = normalizeTimestamp(event.timestamp),
+                            attachments = event.attachments ?: emptyList()
+                        )
+                        activePlanBubbleEventId = null
+                        activePlanBubbleTimestamp = null
+                        activePlanBoundaryUserMessageId = message.id
+                        _messages.add(message)
+                        _unifiedChatTimeline.add(MessageItem(message))
+                        _unifiedChatTimeline.sortBy { it.timestamp }
+                    } else {
+                        // assistant 消息
+                        addAssistantMessage(
+                            event.content,
+                            event.attachments ?: emptyList()
+                        )
+                    }
                 }
             }
             is UIToolEvent -> {
@@ -700,6 +751,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                         // 先移除再添加以确保 Compose 正确触发重组
                         _uiEvents.removeAt(planEventIndex)
                         _uiEvents.add(planEventIndex, updatedPlanEvent)
+                        syncPlanItemInTimeline(updatedPlanEvent)
 
                         Log.d("AlianViewModel", "成功将工具 ${toolCall.name} (tool_call_id=${toolCall.toolCallId}) 关联到 step ${targetStep.id}")
                         System.out.flush()
@@ -720,7 +772,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                 while (_deepThinkingSections.size <= 0) {
                     _deepThinkingSections.add(DeepThinkingSection(
                         eventId = event.eventId,
-                        timestamp = event.timestamp * 1000,  // 转换为毫秒
+                        timestamp = normalizeTimestamp(event.timestamp),
                         title = "深度思考",
                         paragraphs = mutableStateListOf("")  // 主段落
                     ))
@@ -851,6 +903,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                     // 先移除再添加以确保 Compose 正确触发重组
                     _uiEvents.removeAt(planEventIndex)
                     _uiEvents.add(planEventIndex, updatedPlanEvent)
+                    syncPlanItemInTimeline(updatedPlanEvent)
 
                     Log.d("AlianViewModel", "更新 UIPlanEvent 中的步骤: stepId=${event.step.id}, 新状态=${event.step.status}，保留工具列表")
                     System.out.flush()
@@ -859,65 +912,52 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                 }
             }
             is UIPlanEvent -> {
-                // 计划事件 - 直接添加或替换最后一个 plan 事件
+                // 计划事件：同一轮用户输入仅维护一个 Plan 气泡
                 Log.d("AlianViewModel", "收到计划事件: timestamp=${event.timestamp}, eventId=${event.eventId}, steps=${event.steps.size}, steps详情: ${event.steps.map { "id=${it.id}, status=${it.status}, tools=${it.tools.size}" }}")
                 System.out.flush()
 
-                // 查找是否已存在 UIPlanEvent
-                val existingPlanEvent = _uiEvents.filterIsInstance<UIPlanEvent>().firstOrNull()
+                val normalizedEvent = event.copy(timestamp = normalizeTimestamp(event.timestamp))
+                val latestUserMessageId = _messages.lastOrNull { it.isUser }?.id
+                val isNewUserBoundary = latestUserMessageId != null && latestUserMessageId != activePlanBoundaryUserMessageId
 
-                if (existingPlanEvent != null) {
-                    // 保留现有 UIPlanEvent 中的工具调用ID列表和时间戳
-                    Log.d("AlianViewModel", "现有 UIPlanEvent: eventId=${existingPlanEvent.eventId}, timestamp=${existingPlanEvent.timestamp}, steps: ${existingPlanEvent.steps.map { "id=${it.id}, status=${it.status}, toolCallIds=${it.toolCallIds.size}" }}")
-                    val updatedSteps = event.steps.map { newStep ->
-                        // 查找对应的现有 step，保留其工具调用ID列表
+                if (activePlanBubbleEventId == null || isNewUserBoundary) {
+                    activePlanBubbleEventId = normalizedEvent.eventId
+                    activePlanBubbleTimestamp = normalizedEvent.timestamp
+                    activePlanBoundaryUserMessageId = latestUserMessageId
+                }
+
+                val anchorEventId = activePlanBubbleEventId ?: normalizedEvent.eventId
+                val anchorTimestamp = activePlanBubbleTimestamp ?: normalizedEvent.timestamp
+
+                val anchoredEvent = normalizedEvent.copy(
+                    eventId = anchorEventId,
+                    timestamp = anchorTimestamp
+                )
+
+                val existingPlanEventIndex = _uiEvents.indexOfLast {
+                    it is UIPlanEvent && it.eventId == anchorEventId
+                }
+
+                val planEventForTimeline = if (existingPlanEventIndex >= 0) {
+                    val existingPlanEvent = _uiEvents[existingPlanEventIndex] as UIPlanEvent
+                    val updatedSteps = anchoredEvent.steps.map { newStep ->
                         val existingStep = existingPlanEvent.steps.find { it.id == newStep.id }
                         if (existingStep != null) {
-                            Log.d("AlianViewModel", "保留 step ${newStep.id} 的 toolCallIds: ${existingStep.toolCallIds}")
                             newStep.copy(toolCallIds = existingStep.toolCallIds)
                         } else {
-                            Log.w("AlianViewModel", "未找到 step ${newStep.id}，无法保留 toolCallIds")
                             newStep
                         }
                     }
-                    // 保留第一个 plan 事件的时间戳
-                    val updatedPlanEvent = event.copy(
-                        steps = updatedSteps,
-                        timestamp = existingPlanEvent.timestamp
-                    )
-                    // 替换现有的 UIPlanEvent
-                    val existingIndex = _uiEvents.indexOf(existingPlanEvent)
-                    _uiEvents.removeAt(existingIndex)
-                    _uiEvents.add(existingIndex, updatedPlanEvent)
-                    Log.d("AlianViewModel", "更新现有的 UIPlanEvent，保留原始时间戳: ${existingPlanEvent.timestamp}")
+                    val updatedPlanEvent = anchoredEvent.copy(steps = updatedSteps)
+                    _uiEvents[existingPlanEventIndex] = updatedPlanEvent
+                    updatedPlanEvent
                 } else {
-                    // 添加新的 UIPlanEvent，将时间戳转换为毫秒
-                    val planEventWithMsTimestamp = event.copy(timestamp = event.timestamp * 1000)
-                    _uiEvents.add(planEventWithMsTimestamp)
-                    Log.d("AlianViewModel", "添加新的 UIPlanEvent，eventId=${planEventWithMsTimestamp.eventId}, 时间戳: ${planEventWithMsTimestamp.timestamp}")
+                    _uiEvents.add(anchoredEvent)
+                    anchoredEvent
                 }
 
-                // 添加或更新统一时间线中的 PlanItem
-                // 使用更精确的检查：通过 eventId 来判断是否是同一个 plan
-                val planItem = PlanItem(if (existingPlanEvent != null) _uiEvents[_uiEvents.indexOfFirst { it is UIPlanEvent }] as UIPlanEvent else event.copy(timestamp = event.timestamp * 1000))
-                val existingPlanItemIndex = _unifiedChatTimeline.indexOfFirst { 
-                    it is PlanItem && it.planEvent.eventId == planItem.planEvent.eventId 
-                }
-                
-                Log.d("AlianViewModel", "检查 PlanItem: eventId=${planItem.planEvent.eventId}, existingPlanItemIndex=$existingPlanItemIndex, 当前时间线大小=${_unifiedChatTimeline.size}")
-                
-                if (existingPlanItemIndex >= 0) {
-                    _unifiedChatTimeline.removeAt(existingPlanItemIndex)
-                    _unifiedChatTimeline.add(planItem)
-                    // 按时间排序
-                    _unifiedChatTimeline.sortBy { it.timestamp }
-                    Log.d("AlianViewModel", "更新统一时间线中的 PlanItem (eventId=${planItem.planEvent.eventId}, timestamp=${planItem.timestamp}) 并重新排序")
-                } else {
-                    _unifiedChatTimeline.add(planItem)
-                    // 按时间排序
-                    _unifiedChatTimeline.sortBy { it.timestamp }
-                    Log.d("AlianViewModel", "添加 PlanItem (eventId=${planItem.planEvent.eventId}, timestamp=${planItem.timestamp}) 到统一时间线并排序，添加后时间线大小=${_unifiedChatTimeline.size}")
-                }
+                syncPlanItemInTimeline(planEventForTimeline)
+                Log.d("AlianViewModel", "同步 PlanItem 到统一时间线: eventId=${planEventForTimeline.eventId}, timestamp=${planEventForTimeline.timestamp}")
 
                 // 当 plan 消息出现时，折叠所有的 deepthink
                 _unifiedChatTimeline.forEach { item ->
@@ -967,16 +1007,26 @@ class AlianViewModel(private val context: Context) : ViewModel() {
      */
     fun createNewSession() {
         Log.d("AlianViewModel", "创建新Session")
+        sessionLoadJob?.cancel()
+        sessionLoadJob = null
+        activePlanBubbleEventId = null
+        activePlanBubbleTimestamp = null
+        activePlanBoundaryUserMessageId = null
         clearMessages()
         clearUIEvents()
         clearDeepThinkingSections()
         clearToolCalls()
         alianClient?.clearCurrentSession()
+        _currentSessionIdUi.value = null
+        _sessionLoadingState.value = SessionLoadingState.Idle
         Log.d("AlianViewModel", "新Session已创建")
     }
 
     fun clearMessages() {
         _messages.clear()
+        activePlanBubbleEventId = null
+        activePlanBubbleTimestamp = null
+        activePlanBoundaryUserMessageId = null
         // 清除统一时间线中的所有项
         _unifiedChatTimeline.clear()
         // 注意：不清除SessionId，继续使用缓存的Session
@@ -1001,6 +1051,23 @@ class AlianViewModel(private val context: Context) : ViewModel() {
 
     private fun generateMessageId(): String {
         return "msg_${System.currentTimeMillis()}_${_messages.size}"
+    }
+
+    private fun normalizeTimestamp(timestamp: Long): Long {
+        // 10^11 约为 1973 年毫秒时间戳，低于该值基本可判定为秒级时间戳
+        return if (timestamp in 1 until 100_000_000_000L) timestamp * 1000 else timestamp
+    }
+
+    private fun syncPlanItemInTimeline(planEvent: UIPlanEvent) {
+        val planItemIndex = _unifiedChatTimeline.indexOfFirst {
+            it is PlanItem && it.planEvent.eventId == planEvent.eventId
+        }
+        if (planItemIndex >= 0) {
+            _unifiedChatTimeline[planItemIndex] = PlanItem(planEvent)
+        } else {
+            _unifiedChatTimeline.add(PlanItem(planEvent))
+            _unifiedChatTimeline.sortBy { it.timestamp }
+        }
     }
 
     /**
@@ -1120,8 +1187,16 @@ class AlianViewModel(private val context: Context) : ViewModel() {
         Log.d("AlianViewModel", "删除会话: $sessionId")
 
         try {
-            if (!useBackend || alianClient == null) {
+            if (!useBackend) {
                 return@withContext Result.failure(Exception("Backend mode is not enabled"))
+            }
+
+            if (alianClient == null) {
+                updateAlianClient()
+            }
+
+            if (alianClient == null) {
+                return@withContext Result.failure(Exception("Backend client is not initialized"))
             }
 
             val result = alianClient!!.deleteSession(sessionId)
@@ -1143,21 +1218,93 @@ class AlianViewModel(private val context: Context) : ViewModel() {
     }
 
     /**
-     * 选择会话并加载会话消息
+     * 异步选择会话并加载历史消息
+     * 点击历史后立即返回聊天框，数据在后台异步加载
      */
-    suspend fun selectSession(sessionId: String): Result<Unit> = withContext(Dispatchers.IO) {
-        Log.d("AlianViewModel", "选择会话: $sessionId")
+    fun selectSessionAsync(sessionId: String) {
+        if (!useBackend) {
+            _sessionLoadingState.value = SessionLoadingState.Failed(sessionId, "Backend mode is not enabled")
+            return
+        }
+
+        // last-click-wins：取消旧任务，并使用 token 丢弃过时回包
+        sessionLoadJob?.cancel()
+        val token = ++sessionLoadToken
+        lastRequestedSessionId = sessionId
+        _currentSessionIdUi.value = sessionId
+
+        // 切会话时先取消当前问答流，避免旧流事件污染新会话
+        currentMessageJob?.cancel()
+        currentMessageJob = null
+        _isProcessing.value = false
+        resetState()
+        _currentToolName.value = null
+        _currentStepName.value = null
+        clearMessages()
+        clearUIEvents()
+        clearDeepThinkingSections()
+        clearToolCalls()
+        _sessionLoadingState.value = SessionLoadingState.Switching(sessionId)
+
+        sessionLoadJob = viewModelScope.launch {
+            val result = loadSessionInternal(sessionId, token)
+            if (token != sessionLoadToken) {
+                return@launch
+            }
+
+            _sessionLoadingState.value = if (result.isSuccess) {
+                SessionLoadingState.Loaded(sessionId)
+            } else {
+                SessionLoadingState.Failed(
+                    sessionId,
+                    result.exceptionOrNull()?.message ?: "加载会话失败"
+                )
+            }
+        }
+    }
+
+    fun retryCurrentSessionLoad() {
+        val sessionId = lastRequestedSessionId ?: return
+        selectSessionAsync(sessionId)
+    }
+
+    /**
+     * 兼容旧调用链：保留 suspend 接口
+     */
+    suspend fun selectSession(sessionId: String): Result<Unit> {
+        val token = ++sessionLoadToken
+        lastRequestedSessionId = sessionId
+        _currentSessionIdUi.value = sessionId
+        _sessionLoadingState.value = SessionLoadingState.Switching(sessionId)
+        val result = loadSessionInternal(sessionId, token)
+        if (token == sessionLoadToken) {
+            _sessionLoadingState.value = if (result.isSuccess) {
+                SessionLoadingState.Loaded(sessionId)
+            } else {
+                SessionLoadingState.Failed(
+                    sessionId,
+                    result.exceptionOrNull()?.message ?: "加载会话失败"
+                )
+            }
+        }
+        return result
+    }
+
+    private suspend fun loadSessionInternal(sessionId: String, token: Long): Result<Unit> = withContext(Dispatchers.IO) {
+        Log.d("AlianViewModel", "异步加载会话: $sessionId, token=$token")
 
         try {
-            if (!useBackend || alianClient == null) {
+            if (!useBackend) {
                 return@withContext Result.failure(Exception("Backend mode is not enabled"))
             }
 
-            // 清除当前消息
-            clearMessages()
-            clearUIEvents()
-            clearDeepThinkingSections()
-            clearToolCalls()
+            if (alianClient == null) {
+                updateAlianClient()
+            }
+
+            if (alianClient == null) {
+                return@withContext Result.failure(Exception("Backend client is not initialized"))
+            }
 
             // 设置当前会话ID
             alianClient!!.setCurrentSessionId(sessionId)
@@ -1166,50 +1313,27 @@ class AlianViewModel(private val context: Context) : ViewModel() {
             val detailResult = alianClient!!.getSessionDetail(sessionId)
 
             if (detailResult.isSuccess) {
-                val detail = detailResult.getOrNull()!!
-                Log.d("AlianViewModel", "会话详细信息加载成功，共 ${detail.events.size} 个事件")
-
-                // 处理事件列表
-                processSessionEvents(detail.events)
-
-                // 检测是否是新接口（通过事件类型判断）
-                val isNewApi = detail.events.any { event ->
-                    event.event in listOf("user_message", "text_message_start", "plan_started", "plan_finished")
+                if (token != sessionLoadToken) {
+                    Log.d("AlianViewModel", "会话加载结果过期，丢弃: sessionId=$sessionId, token=$token")
+                    return@withContext Result.success(Unit)
                 }
 
-                // 如果是新接口，获取附件并附加到最后一条 assistant 消息
-                if (isNewApi && _messages.isNotEmpty()) {
-                    val backendClient = getBackendClient()
-                    if (backendClient != null) {
-                        Log.d("AlianViewModel", "检测到新接口，尝试获取附件")
-                        val attachmentsResult = backendClient.getSessionAttachments(sessionId)
-                        if (attachmentsResult.isSuccess) {
-                            val attachments = attachmentsResult.getOrNull()!!
-                            if (attachments.isNotEmpty()) {
-                                // 找到最后一条 assistant 消息在 _messages 中的索引
-                                val lastAssistantIndex = _messages.indexOfLast { !it.isUser }
-                                if (lastAssistantIndex >= 0) {
-                                    val lastMessage = _messages[lastAssistantIndex]
-                                    val updatedMessage = lastMessage.copy(
-                                        attachments = attachments
-                                    )
-                                    _messages[lastAssistantIndex] = updatedMessage
-                                    
-                                    // 同步更新 _unifiedChatTimeline 中的 MessageItem
-                                    val timelineIndex = _unifiedChatTimeline.indexOfFirst { 
-                                        it is MessageItem && it.message.id == lastMessage.id 
-                                    }
-                                    if (timelineIndex >= 0) {
-                                        _unifiedChatTimeline[timelineIndex] = MessageItem(updatedMessage)
-                                    }
-                                    
-                                    Log.d("AlianViewModel", "已将 ${attachments.size} 个附件附加到最后一条 assistant 消息")
-                                }
-                            }
-                        } else {
-                            Log.w("AlianViewModel", "获取附件失败: ${attachmentsResult.exceptionOrNull()?.message}")
-                        }
+                val detail = detailResult.getOrNull()!!
+                Log.d("AlianViewModel", "会话详细信息加载成功，共 ${detail.events.size} 个事件")
+                val backendClient = getBackendClient()
+                // 首屏历史加载不再做附件签名预处理，避免 252k 事件场景被串行签名请求阻塞
+                val normalizedEvents = detail.events
+
+                withContext(Dispatchers.Main) mainContext@{
+                    if (token != sessionLoadToken) {
+                        return@mainContext
                     }
+                    processSessionEvents(normalizedEvents, token, sessionId)
+                }
+
+                // 附件兜底放到后台异步，避免阻塞历史加载完成态
+                if (backendClient != null) {
+                    loadSessionAttachmentsFallbackAsync(sessionId, backendClient, token)
                 }
 
                 Log.d("AlianViewModel", "会话事件处理完成，统一时间线大小: ${_unifiedChatTimeline.size}")
@@ -1219,16 +1343,145 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                 Log.e("AlianViewModel", "加载会话详细信息失败: $errorMsg")
                 Result.failure(Exception(errorMsg))
             }
+        } catch (e: CancellationException) {
+            Log.d("AlianViewModel", "会话加载取消: sessionId=$sessionId, token=$token")
+            Result.failure(e)
         } catch (e: Exception) {
             Log.e("AlianViewModel", "选择会话异常", e)
             Result.failure(e)
         }
     }
 
+    private suspend fun normalizeSessionEventsAttachments(
+        events: List<SessionEvent>,
+        backendClient: BackendChatClient?
+    ): List<SessionEvent> = withContext(Dispatchers.IO) {
+        if (backendClient == null) {
+            return@withContext events
+        }
+
+        val signedUrlCache = mutableMapOf<String, String>()
+
+        events.map { event ->
+            if (event.event != "plan_finished") {
+                return@map event
+            }
+
+            try {
+                val dataString = json.encodeToString(event.data)
+                val planData = json.decodeFromString<PlanFinishedData>(dataString)
+                val attachments = planData.attachments ?: emptyList()
+                if (attachments.isEmpty()) {
+                    return@map event
+                }
+
+                val resolvedAttachments = attachments.map { attachment ->
+                    val hasUsableUrl = !attachment.file_url.isNullOrBlank() || !attachment.url.isNullOrBlank()
+                    if (hasUsableUrl) {
+                        attachment
+                    } else {
+                        val fileId = attachment.file_id
+                        if (fileId.isNullOrBlank()) {
+                            attachment
+                        } else {
+                            val signedUrl = signedUrlCache[fileId] ?: run {
+                                val signedUrlResult = backendClient.getFileSignedUrl(fileId)
+                                if (signedUrlResult.isSuccess) {
+                                    val url = signedUrlResult.getOrNull()!!
+                                    signedUrlCache[fileId] = url
+                                    url
+                                } else {
+                                    Log.w("AlianViewModel", "file_id=$fileId 签名URL获取失败: ${signedUrlResult.exceptionOrNull()?.message}")
+                                    ""
+                                }
+                            }
+
+                            if (signedUrl.isNotBlank()) {
+                                attachment.copy(
+                                    file_url = signedUrl,
+                                    url = signedUrl
+                                )
+                            } else {
+                                attachment
+                            }
+                        }
+                    }
+                }
+
+                val normalizedPlanData = planData.copy(attachments = resolvedAttachments)
+                SessionEvent(
+                    event = event.event,
+                    data = json.encodeToJsonElement(normalizedPlanData)
+                )
+            } catch (e: Exception) {
+                Log.e("AlianViewModel", "标准化 plan_finished 附件失败，保持原始事件", e)
+                event
+            }
+        }
+    }
+
+    private fun attachSessionFilesAsFallback(attachments: List<Attachment>) {
+        val hasAnyMessageAttachment = _messages.any { it.attachments.isNotEmpty() }
+        if (hasAnyMessageAttachment) {
+            return
+        }
+
+        val lastAssistantIndex = _messages.indexOfLast { !it.isUser }
+        if (lastAssistantIndex < 0) {
+            return
+        }
+
+        val lastMessage = _messages[lastAssistantIndex]
+        val mergedAttachments = (lastMessage.attachments + attachments).distinctBy {
+            it.file_id ?: it.file_url ?: it.url ?: it.path ?: it.filename ?: it.name
+        }
+        val updatedMessage = lastMessage.copy(attachments = mergedAttachments)
+        _messages[lastAssistantIndex] = updatedMessage
+
+        val timelineIndex = _unifiedChatTimeline.indexOfFirst {
+            it is MessageItem && it.message.id == lastMessage.id
+        }
+        if (timelineIndex >= 0) {
+            _unifiedChatTimeline[timelineIndex] = MessageItem(updatedMessage)
+        }
+
+        Log.d("AlianViewModel", "历史附件兜底挂载到最后一条 assistant 消息: ${mergedAttachments.size} 个")
+    }
+
+    private fun loadSessionAttachmentsFallbackAsync(
+        sessionId: String,
+        backendClient: BackendChatClient,
+        token: Long
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            if (token != sessionLoadToken) {
+                return@launch
+            }
+            val attachmentsResult = backendClient.getSessionAttachments(sessionId)
+            if (attachmentsResult.isSuccess) {
+                val attachments = attachmentsResult.getOrNull().orEmpty()
+                if (attachments.isNotEmpty()) {
+                    withContext(Dispatchers.Main) {
+                        if (token != sessionLoadToken) {
+                            return@withContext
+                        }
+                        attachSessionFilesAsFallback(attachments)
+                    }
+                }
+            } else {
+                Log.w("AlianViewModel", "获取会话附件失败: ${attachmentsResult.exceptionOrNull()?.message}")
+            }
+        }
+    }
+
     /**
      * 处理会话事件列表，转换为消息和UI事件
      */
-    private fun processSessionEvents(events: List<SessionEvent>) {
+    private suspend fun processSessionEvents(
+        events: List<SessionEvent>,
+        loadToken: Long,
+        sessionId: String
+    ) {
         // 辅助函数：将 JsonElement 正确序列化为 JSON 字符串
         fun JsonElement.toJsonString(): String = json.encodeToString(this)
 
@@ -1237,7 +1490,58 @@ class AlianViewModel(private val context: Context) : ViewModel() {
         val messageTimestamps = mutableMapOf<String, Long>()
         // 用于收集每个消息的附件
         val messageAttachments = mutableMapOf<String, MutableList<Attachment>>()
+        // plan_finished 先于 assistant 消息到达时，暂存附件并在下一条 assistant 消息写入时合并
+        val pendingAssistantAttachments = mutableListOf<Attachment>()
 
+        fun mergeAttachments(
+            primary: List<Attachment>,
+            secondary: List<Attachment>
+        ): List<Attachment> {
+            return (primary + secondary).distinctBy {
+                it.file_id ?: it.file_url ?: it.url ?: it.path ?: it.filename ?: it.name
+            }
+        }
+
+        var switchingMarkedLoaded = false
+        fun markSwitchingLoadedOnce() {
+            if (switchingMarkedLoaded) return
+            if (loadToken != sessionLoadToken) return
+            if (_sessionLoadingState.value is SessionLoadingState.Switching) {
+                _sessionLoadingState.value = SessionLoadingState.Loaded(sessionId)
+            }
+            switchingMarkedLoaded = true
+        }
+
+        fun addHistoryMessage(message: ChatMessage) {
+            markSwitchingLoadedOnce()
+            _messages.add(message)
+            _unifiedChatTimeline.add(MessageItem(message))
+        }
+
+        fun attachOrQueuePlanFinishedAttachments(attachments: List<Attachment>) {
+            if (attachments.isEmpty()) return
+
+            val lastAssistantIndex = _messages.indexOfLast { !it.isUser }
+            if (lastAssistantIndex >= 0) {
+                val lastAssistant = _messages[lastAssistantIndex]
+                val merged = mergeAttachments(lastAssistant.attachments, attachments)
+                val updated = lastAssistant.copy(attachments = merged)
+                _messages[lastAssistantIndex] = updated
+
+                val timelineIndex = _unifiedChatTimeline.indexOfFirst {
+                    it is MessageItem && it.message.id == lastAssistant.id
+                }
+                if (timelineIndex >= 0) {
+                    _unifiedChatTimeline[timelineIndex] = MessageItem(updated)
+                }
+                Log.d("AlianViewModel", "plan_finished 附件已挂载到最后一条 assistant: ${attachments.size} 个")
+            } else {
+                pendingAssistantAttachments.addAll(attachments)
+                Log.d("AlianViewModel", "plan_finished 附件暂存，等待 assistant 消息: ${attachments.size} 个")
+            }
+        }
+
+        var processedEventCount = 0
         events.forEach { event ->
             when (event.event) {
                 "message" -> {
@@ -1245,18 +1549,30 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                     try {
                         val dataString = event.data.toJsonString()
                         val messageData = json.decodeFromString<MessageData>(dataString)
-                        Log.d("AlianViewModel", "处理消息事件: role=${messageData.role}, content=${messageData.content.take(50)}...")
 
                         if (messageData.role == "user" || messageData.role == "assistant") {
+                            if (messageData.role == "user") {
+                                activePlanBubbleEventId = null
+                                activePlanBubbleTimestamp = null
+                                activePlanBoundaryUserMessageId = messageData.message_id
+                            }
                             // 不再在 content 中显示附件链接，因为已经有预览按钮了
                             val contentWithAttachments = messageData.content
+                            val rawAttachments = messageData.attachments ?: emptyList()
+                            val mergedAttachments = if (messageData.role == "assistant" && pendingAssistantAttachments.isNotEmpty()) {
+                                val merged = mergeAttachments(rawAttachments, pendingAssistantAttachments)
+                                pendingAssistantAttachments.clear()
+                                merged
+                            } else {
+                                rawAttachments
+                            }
 
-                            _messages.add(ChatMessage(
+                            addHistoryMessage(ChatMessage(
                                 id = messageData.message_id ?: generateMessageId(),
                                 content = contentWithAttachments,
                                 isUser = messageData.role == "user",
-                                timestamp = messageData.timestamp * 1000,
-                                attachments = messageData.attachments ?: emptyList()
+                                timestamp = normalizeTimestamp(messageData.timestamp),
+                                attachments = mergedAttachments
                             ))
                         }
                     } catch (e: Exception) {
@@ -1268,18 +1584,16 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                     try {
                         val dataString = event.data.toJsonString()
                         val chunkData = json.decodeFromString<MessageChunkData>(dataString)
-                        Log.d("AlianViewModel", "处理消息块事件: messageId=${chunkData.message_id}, chunkIndex=${chunkData.chunk_index}")
 
                         // 累积消息块
                         val buffer = messageChunkBuffer.getOrPut(chunkData.message_id) { StringBuilder() }
                         buffer.append(chunkData.chunk)
-                        messageTimestamps[chunkData.message_id] = chunkData.timestamp
+                        messageTimestamps[chunkData.message_id] = normalizeTimestamp(chunkData.timestamp)
 
                         // 收集附件
                         if (chunkData.attachments != null && chunkData.attachments.isNotEmpty()) {
                             val attachments = messageAttachments.getOrPut(chunkData.message_id) { mutableListOf() }
                             attachments.addAll(chunkData.attachments)
-                            Log.d("AlianViewModel", "收集到 ${chunkData.attachments.size} 个附件到消息 ${chunkData.message_id}")
                         }
 
                         // 如果是最后一个块，创建完整消息
@@ -1287,13 +1601,21 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                             val fullContent = buffer.toString()
                             // 不再在 content 中显示附件链接，因为已经有预览按钮了
                             val contentWithAttachments = fullContent
+                            val rawAttachments = messageAttachments[chunkData.message_id] ?: emptyList()
+                            val mergedAttachments = if (pendingAssistantAttachments.isNotEmpty()) {
+                                val merged = mergeAttachments(rawAttachments, pendingAssistantAttachments)
+                                pendingAssistantAttachments.clear()
+                                merged
+                            } else {
+                                rawAttachments
+                            }
 
-                            _messages.add(ChatMessage(
+                            addHistoryMessage(ChatMessage(
                                 id = chunkData.message_id,
                                 content = contentWithAttachments,
                                 isUser = false,  // message_chunk 通常是 assistant 的消息
-                                timestamp = chunkData.timestamp * 1000,
-                                attachments = messageAttachments[chunkData.message_id] ?: emptyList()
+                                timestamp = normalizeTimestamp(chunkData.timestamp),
+                                attachments = mergedAttachments
                             ))
                             // 清理缓冲区
                             messageChunkBuffer.remove(chunkData.message_id)
@@ -1315,7 +1637,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                         while (_deepThinkingSections.size <= 0) {
                             _deepThinkingSections.add(DeepThinkingSection(
                                 eventId = chunkData.event_id,
-                                timestamp = chunkData.timestamp * 1000,
+                                timestamp = normalizeTimestamp(chunkData.timestamp),
                                 title = "深度思考",
                                 paragraphs = mutableStateListOf("")  // 主段落
                             ))
@@ -1405,7 +1727,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                         addUIEvent(
                             UIToolEvent(
                                 eventId = toolData.event_id,
-                                timestamp = toolData.timestamp,
+                                timestamp = normalizeTimestamp(toolData.timestamp),
                                 toolCall = uiToolCall
                             )
                         )
@@ -1425,10 +1747,10 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                             description = stepData.description,
                             status = stepData.status
                         )
-                        _uiEvents.add(
+                        addUIEvent(
                             UIStepEvent(
                                 eventId = stepData.event_id,
-                                timestamp = stepData.timestamp,
+                                timestamp = normalizeTimestamp(stepData.timestamp),
                                 step = uiStep
                             )
                         )
@@ -1443,56 +1765,21 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                         val planData = json.decodeFromString<PlanData>(dataString)
                         Log.d("AlianViewModel", "处理计划事件: steps=${planData.steps.size}")
 
-                        // 查找是否已存在 UIPlanEvent
-                        val existingPlanEvent = _uiEvents.filterIsInstance<UIPlanEvent>().firstOrNull()
-
-                        val uiSteps = if (existingPlanEvent != null) {
-                            // 保留现有步骤的 toolCallIds
-                            val existingStepsMap = existingPlanEvent.steps.associateBy { it.id }
-                            planData.steps.map { step ->
-                                val existingStep = existingStepsMap[step.id]
-                                UIStep(
-                                    id = step.id,
-                                    description = step.description,
-                                    status = step.status,
-                                    toolCallIds = existingStep?.toolCallIds
-                                        ?: emptyList()  // 保留 toolCallIds
-                                )
-                            }
-                        } else {
-                            // 创建新的 UIStep
-                            planData.steps.map { step ->
-                                UIStep(
-                                    id = step.id,
-                                    description = step.description,
-                                    status = step.status
-                                )
-                            }
+                        val uiSteps = planData.steps.map { step ->
+                            UIStep(
+                                id = step.id,
+                                description = step.description,
+                                status = step.status
+                            )
                         }
 
-                        if (existingPlanEvent != null) {
-                            // 保留第一个 plan 事件的时间戳
-                            val updatedPlanEvent = UIPlanEvent(
+                        addUIEvent(
+                            UIPlanEvent(
                                 eventId = planData.event_id,
-                                timestamp = existingPlanEvent.timestamp,  // 保留第一个的时间戳
+                                timestamp = normalizeTimestamp(planData.timestamp),
                                 steps = uiSteps
                             )
-                            // 替换现有的 UIPlanEvent
-                            val existingIndex = _uiEvents.indexOf(existingPlanEvent)
-                            _uiEvents.removeAt(existingIndex)
-                            _uiEvents.add(existingIndex, updatedPlanEvent)
-                            Log.d("AlianViewModel", "更新现有的 UIPlanEvent，保留原始时间戳: ${existingPlanEvent.timestamp} 和 toolCallIds")
-                        } else {
-                            // 添加新的 UIPlanEvent
-                            _uiEvents.add(
-                                UIPlanEvent(
-                                    eventId = planData.event_id,
-                                    timestamp = planData.timestamp * 1000,  // 乘以 1000 转换为毫秒
-                                    steps = uiSteps
-                                )
-                            )
-                            Log.d("AlianViewModel", "添加新的 UIPlanEvent，时间戳: ${planData.timestamp * 1000}")
-                        }
+                        )
                     } catch (e: Exception) {
                         Log.e("AlianViewModel", "解析计划事件失败", e)
                     }
@@ -1506,7 +1793,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                         Log.d("AlianViewModel", "处理文本消息开始事件: message_id=${startData.message_id}, message_type=${startData.message_type}")
                         // 初始化消息缓冲区
                         messageChunkBuffer.getOrPut(startData.message_id) { StringBuilder() }
-                        messageTimestamps[startData.message_id] = startData.timestamp
+                        messageTimestamps[startData.message_id] = normalizeTimestamp(startData.timestamp)
                     } catch (e: Exception) {
                         Log.e("AlianViewModel", "解析文本消息开始事件失败", e)
                     }
@@ -1516,12 +1803,11 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                     try {
                         val dataString = event.data.toJsonString()
                         val chunkData = json.decodeFromString<TextMessageChunkData>(dataString)
-                        Log.d("AlianViewModel", "处理文本消息块事件: message_id=${chunkData.message_id}, delta=${chunkData.delta.take(50)}...")
 
                         // 累积消息块
                         val buffer = messageChunkBuffer.getOrPut(chunkData.message_id) { StringBuilder() }
                         buffer.append(chunkData.delta)
-                        messageTimestamps[chunkData.message_id] = chunkData.timestamp
+                        messageTimestamps[chunkData.message_id] = normalizeTimestamp(chunkData.timestamp)
                     } catch (e: Exception) {
                         Log.e("AlianViewModel", "解析文本消息块事件失败", e)
                     }
@@ -1538,12 +1824,20 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                         if (buffer != null) {
                             val fullContent = buffer.toString()
                             if (fullContent.isNotBlank()) {
-                                _messages.add(ChatMessage(
+                                val rawAttachments = messageAttachments[endData.message_id] ?: emptyList()
+                                val mergedAttachments = if (pendingAssistantAttachments.isNotEmpty()) {
+                                    val merged = mergeAttachments(rawAttachments, pendingAssistantAttachments)
+                                    pendingAssistantAttachments.clear()
+                                    merged
+                                } else {
+                                    rawAttachments
+                                }
+                                addHistoryMessage(ChatMessage(
                                     id = endData.message_id,
                                     content = fullContent,
                                     isUser = false,
-                                    timestamp = (messageTimestamps[endData.message_id] ?: endData.timestamp) * 1000,
-                                    attachments = messageAttachments[endData.message_id] ?: emptyList()
+                                    timestamp = normalizeTimestamp(messageTimestamps[endData.message_id] ?: endData.timestamp),
+                                    attachments = mergedAttachments
                                 ))
                             }
                             // 清理缓冲区
@@ -1560,13 +1854,15 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                     try {
                         val dataString = event.data.toJsonString()
                         val userData = json.decodeFromString<UserMessageData>(dataString)
-                        Log.d("AlianViewModel", "处理用户消息事件: message_id=${userData.message_id}, message=${userData.message.take(50)}...")
+                        activePlanBubbleEventId = null
+                        activePlanBubbleTimestamp = null
+                        activePlanBoundaryUserMessageId = userData.message_id
 
-                        _messages.add(ChatMessage(
+                        addHistoryMessage(ChatMessage(
                             id = userData.message_id,
                             content = userData.message,
                             isUser = true,
-                            timestamp = userData.timestamp * 1000,
+                            timestamp = normalizeTimestamp(userData.timestamp),
                             attachments = userData.attachments ?: emptyList()
                         ))
                     } catch (e: Exception) {
@@ -1676,10 +1972,10 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                                 status = phase.status
                             )
                         }
-                        _uiEvents.add(
+                        addUIEvent(
                             UIPlanEvent(
                                 eventId = planData.id,
-                                timestamp = planData.timestamp,
+                                timestamp = normalizeTimestamp(planData.timestamp),
                                 steps = uiSteps
                             )
                         )
@@ -1702,26 +1998,14 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                             )
                         }
 
-                        // 查找是否已存在 UIPlanEvent
-                        val existingPlanEvent = _uiEvents.filterIsInstance<UIPlanEvent>().firstOrNull()
-                        if (existingPlanEvent != null) {
-                            val updatedPlanEvent = UIPlanEvent(
+                        addUIEvent(
+                            UIPlanEvent(
                                 eventId = planData.id,
-                                timestamp = existingPlanEvent.timestamp,
+                                timestamp = normalizeTimestamp(planData.timestamp),
                                 steps = uiSteps
                             )
-                            val existingIndex = _uiEvents.indexOf(existingPlanEvent)
-                            _uiEvents.removeAt(existingIndex)
-                            _uiEvents.add(existingIndex, updatedPlanEvent)
-                        } else {
-                            _uiEvents.add(
-                                UIPlanEvent(
-                                    eventId = planData.id,
-                                    timestamp = planData.timestamp,
-                                    steps = uiSteps
-                                )
-                            )
-                        }
+                        )
+                        attachOrQueuePlanFinishedAttachments(planData.attachments ?: emptyList())
                     } catch (e: Exception) {
                         Log.e("AlianViewModel", "解析计划完成事件失败", e)
                     }
@@ -1733,10 +2017,10 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                         val phaseData = json.decodeFromString<PhaseStartedData>(dataString)
                         Log.d("AlianViewModel", "处理阶段开始事件: phase_id=${phaseData.phase_id}, title=${phaseData.title}")
 
-                        _uiEvents.add(
+                        addUIEvent(
                             UIStepEvent(
                                 eventId = phaseData.id,
-                                timestamp = phaseData.timestamp,
+                                timestamp = normalizeTimestamp(phaseData.timestamp),
                                 step = UIStep(
                                     id = phaseData.phase_id,
                                     description = phaseData.title,
@@ -1755,10 +2039,10 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                         val phaseData = json.decodeFromString<PhaseFinishedData>(dataString)
                         Log.d("AlianViewModel", "处理阶段完成事件: phase_id=${phaseData.phase_id}, title=${phaseData.title}")
 
-                        _uiEvents.add(
+                        addUIEvent(
                             UIStepEvent(
                                 eventId = phaseData.id,
-                                timestamp = phaseData.timestamp,
+                                timestamp = normalizeTimestamp(phaseData.timestamp),
                                 step = UIStep(
                                     id = phaseData.phase_id,
                                     description = phaseData.title,
@@ -1776,20 +2060,42 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                     Log.d("AlianViewModel", "忽略事件类型: ${event.event}")
                 }
             }
+
+            processedEventCount++
+            if (processedEventCount == 1) {
+                markSwitchingLoadedOnce()
+            }
+            if (processedEventCount % 16 == 0) {
+                if (loadToken != sessionLoadToken) {
+                    Log.d("AlianViewModel", "事件处理中检测到会话切换，提前终止: token=$loadToken, current=$sessionLoadToken")
+                    return
+                }
+                yield()
+            }
         }
+
+        markSwitchingLoadedOnce()
 
         // 处理剩余的未完成消息块（如果有）
         messageChunkBuffer.forEach { (messageId, buffer) ->
             val fullContent = buffer.toString()
             if (fullContent.isNotBlank()) {
                 // 不再在 content 中显示附件链接，因为已经有预览按钮了
-                                            val contentWithAttachments = fullContent
-                _messages.add(ChatMessage(
+                val contentWithAttachments = fullContent
+                val rawAttachments = messageAttachments[messageId] ?: emptyList()
+                val mergedAttachments = if (pendingAssistantAttachments.isNotEmpty()) {
+                    val merged = mergeAttachments(rawAttachments, pendingAssistantAttachments)
+                    pendingAssistantAttachments.clear()
+                    merged
+                } else {
+                    rawAttachments
+                }
+                addHistoryMessage(ChatMessage(
                     id = messageId,
                     content = contentWithAttachments,
                     isUser = false,
-                    timestamp = (messageTimestamps[messageId] ?: System.currentTimeMillis() / 1000) * 1000,
-                    attachments = messageAttachments[messageId] ?: emptyList()
+                    timestamp = normalizeTimestamp(messageTimestamps[messageId] ?: System.currentTimeMillis()),
+                    attachments = mergedAttachments
                 ))
             }
         }
@@ -1810,11 +2116,6 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                 section.paragraphs[1] = ""
                 Log.d("AlianViewModel", "将深度思考章节剩余缓冲区内容包裹在引用块中添加到主段落")
             }
-        }
-
-        // 将所有消息添加到统一时间线
-        _messages.forEach { message ->
-            _unifiedChatTimeline.add(MessageItem(message))
         }
 
         // 将所有深度思考章节添加到统一时间线

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -846,4 +846,8 @@
     <string name="flow_template_skip_screenshot">Skip screenshot (confidence: %1$d%%)</string>
     <string name="flow_template_verification">Verifying node...</string>
     <string name="flow_template_fallback">Fallback to traditional mode</string>
+
+    <!-- Settings Subtitles -->
+    <string name="settings_item_help_subtitle">Usage guide &amp; tips</string>
+    <string name="settings_item_about_subtitle">Version &amp; licenses</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -851,4 +851,8 @@
     <string name="flow_template_skip_screenshot">跳过截图 (置信度: %1$d%%)</string>
     <string name="flow_template_verification">验证节点...</string>
     <string name="flow_template_fallback">降级到传统模式</string>
+
+    <!-- Settings Subtitles -->
+    <string name="settings_item_help_subtitle">使用指南与技巧</string>
+    <string name="settings_item_about_subtitle">版本与开源许可</string>
 </resources>


### PR DESCRIPTION
- MCPClient 添加 SSE 和 Streamable HTTP 传输协议支持
- MCPServerConfig 更新传输类型配置
- AlianViewModel 优化会话历史加载，支持 plan_finished 附件合并
- SettingsScreen 添加 initialSubScreen 导航支持
- 时间戳标准化处理，修复历史消息加载竞态条件