### PR TITLE
feat: 火山引擎 ASR/TTS v3 协议升级与多提供商切换支持

### DIFF
--- a/app/src/main/java/com/alian/assistant/MainActivity.kt
+++ b/app/src/main/java/com/alian/assistant/MainActivity.kt
@@ -1359,6 +1359,7 @@ class MainActivity : ComponentActivity() {
                                 } else {
                                     VoiceSelectionScreen(
                                         currentVoice = settings.ttsVoice,
+                                        currentProvider = settings.speechProvider,
                                         onBack = {
                                             settingsInitialSubScreen = SettingsSubScreen.ALIAN
                                             currentScreen = Screen.Settings

--- a/app/src/main/java/com/alian/assistant/data/SettingsManager.kt
+++ b/app/src/main/java/com/alian/assistant/data/SettingsManager.kt
@@ -387,7 +387,12 @@ class SettingsManager(context: Context) {
         val credentials = mutableMapOf<SpeechProvider, SpeechProviderCredentials>()
         for (provider in SpeechProvider.entries) {
             val cred = loadSpeechCredentials(provider)
-            if (cred.apiKey.isNotEmpty() || cred.appId.isNotEmpty()) {
+            if (
+                cred.apiKey.isNotEmpty() ||
+                cred.appId.isNotEmpty() ||
+                cred.asrResourceId.isNotEmpty() ||
+                cred.ttsResourceId.isNotEmpty()
+            ) {
                 credentials[provider] = cred
             }
         }
@@ -812,8 +817,30 @@ class SettingsManager(context: Context) {
      * 切换 ASR/TTS 服务商
      */
     fun selectSpeechProvider(provider: SpeechProvider) {
-        prefs.edit().putString("speech_provider", provider.name).apply()
-        _settings.value = _settings.value.copy(speechProvider = provider)
+        val oldProvider = _settings.value.speechProvider
+        val switched = oldProvider != provider
+        val nextVoice = if (switched) {
+            getDefaultVoiceForProvider(provider)
+        } else {
+            _settings.value.ttsVoice
+        }
+
+        prefs.edit()
+            .putString("speech_provider", provider.name)
+            .putString("tts_voice", nextVoice)
+            .apply()
+
+        _settings.value = _settings.value.copy(
+            speechProvider = provider,
+            ttsVoice = nextVoice
+        )
+    }
+
+    private fun getDefaultVoiceForProvider(provider: SpeechProvider): String {
+        return when (provider) {
+            SpeechProvider.BAILIAN -> "longyingmu_v3"
+            SpeechProvider.VOLCANO -> "zh_female_shuangkuaisisi_uranus_bigtts"
+        }
     }
 
     /**
@@ -831,6 +858,8 @@ class SettingsManager(context: Context) {
             .putString("speech_${provider.name}_api_key", credentials.apiKey)
             .putString("speech_${provider.name}_app_id", credentials.appId)
             .putString("speech_${provider.name}_cluster", credentials.cluster)
+            .putString("speech_${provider.name}_asr_resource_id", credentials.asrResourceId)
+            .putString("speech_${provider.name}_tts_resource_id", credentials.ttsResourceId)
             .apply()
 
         _settings.value = _settings.value.copy(speechCredentials = newCredentials)
@@ -847,10 +876,72 @@ class SettingsManager(context: Context) {
      * 从存储加载服务商凭证
      */
     private fun loadSpeechCredentials(provider: SpeechProvider): SpeechProviderCredentials {
+        val secureApiKey = (securePrefs.getString("speech_${provider.name}_api_key", "") ?: "").trim()
+        val secureAppId = securePrefs.getString("speech_${provider.name}_app_id", "") ?: ""
+        val secureCluster = securePrefs.getString("speech_${provider.name}_cluster", "") ?: ""
+        val secureAsrResourceId = securePrefs.getString("speech_${provider.name}_asr_resource_id", "") ?: ""
+        val secureTtsResourceId = securePrefs.getString("speech_${provider.name}_tts_resource_id", "") ?: ""
+
+        if (
+            secureAppId.isNotEmpty() ||
+            secureCluster.isNotEmpty() ||
+            secureApiKey.isNotEmpty() ||
+            secureAsrResourceId.isNotEmpty() ||
+            secureTtsResourceId.isNotEmpty()
+        ) {
+            return SpeechProviderCredentials(
+                apiKey = secureApiKey,
+                appId = secureAppId,
+                cluster = secureCluster,
+                asrResourceId = secureAsrResourceId,
+                ttsResourceId = secureTtsResourceId
+            )
+        }
+
+        // 兼容旧版本：如果历史数据存于普通 prefs，则迁移到加密存储
+        val legacyApiKey = (prefs.getString("speech_${provider.name}_api_key", "") ?: "").trim()
+        val legacyAppId = prefs.getString("speech_${provider.name}_app_id", "") ?: ""
+        val legacyCluster = prefs.getString("speech_${provider.name}_cluster", "") ?: ""
+        val legacyAsrResourceId = prefs.getString("speech_${provider.name}_asr_resource_id", "") ?: ""
+        val legacyTtsResourceId = prefs.getString("speech_${provider.name}_tts_resource_id", "") ?: ""
+        if (
+            legacyApiKey.isNotEmpty() ||
+            legacyAppId.isNotEmpty() ||
+            legacyCluster.isNotEmpty() ||
+            legacyAsrResourceId.isNotEmpty() ||
+            legacyTtsResourceId.isNotEmpty()
+        ) {
+            securePrefs.edit()
+                .putString("speech_${provider.name}_api_key", legacyApiKey)
+                .putString("speech_${provider.name}_app_id", legacyAppId)
+                .putString("speech_${provider.name}_cluster", legacyCluster)
+                .putString("speech_${provider.name}_asr_resource_id", legacyAsrResourceId)
+                .putString("speech_${provider.name}_tts_resource_id", legacyTtsResourceId)
+                .apply()
+
+            prefs.edit()
+                .remove("speech_${provider.name}_api_key")
+                .remove("speech_${provider.name}_app_id")
+                .remove("speech_${provider.name}_cluster")
+                .remove("speech_${provider.name}_asr_resource_id")
+                .remove("speech_${provider.name}_tts_resource_id")
+                .apply()
+
+            return SpeechProviderCredentials(
+                apiKey = legacyApiKey,
+                appId = legacyAppId,
+                cluster = legacyCluster,
+                asrResourceId = legacyAsrResourceId,
+                ttsResourceId = legacyTtsResourceId
+            )
+        }
+
         return SpeechProviderCredentials(
-            apiKey = (securePrefs.getString("speech_${provider.name}_api_key", "") ?: "").trim(),
-            appId = prefs.getString("speech_${provider.name}_app_id", "") ?: "",
-            cluster = prefs.getString("speech_${provider.name}_cluster", "") ?: ""
+            apiKey = "",
+            appId = "",
+            cluster = "",
+            asrResourceId = "",
+            ttsResourceId = ""
         )
     }
 
@@ -878,9 +969,27 @@ class SettingsManager(context: Context) {
      * 从存储加载服务商模型选择
      */
     private fun loadSpeechModels(provider: SpeechProvider): SpeechModels {
+        val asrModelKey = "speech_${provider.name}_asr_model"
+        val ttsModelKey = "speech_${provider.name}_tts_model"
+
+        val asrModelRaw = prefs.getString(asrModelKey, "") ?: ""
+        val normalizedAsrModel = if (
+            provider == SpeechProvider.VOLCANO &&
+            asrModelRaw == "volc.seedasr.auc"
+        ) {
+            // 兼容旧配置：AUC 是录音文件识别资源，不适用于流式通话 ASR
+            "volc.seedasr.sauc.duration"
+        } else {
+            asrModelRaw
+        }
+
+        if (normalizedAsrModel != asrModelRaw) {
+            prefs.edit().putString(asrModelKey, normalizedAsrModel).apply()
+        }
+
         return SpeechModels(
-            asrModel = prefs.getString("speech_${provider.name}_asr_model", "") ?: "",
-            ttsModel = prefs.getString("speech_${provider.name}_tts_model", "") ?: ""
+            asrModel = normalizedAsrModel,
+            ttsModel = prefs.getString(ttsModelKey, "") ?: ""
         )
     }
 }

--- a/app/src/main/java/com/alian/assistant/data/model/SpeechProvider.kt
+++ b/app/src/main/java/com/alian/assistant/data/model/SpeechProvider.kt
@@ -20,7 +20,9 @@ data class SpeechProviderCredentials(
     val apiKey: String = "",
     // 火山引擎特有
     val appId: String = "",
-    val cluster: String = ""
+    val cluster: String = "",
+    val asrResourceId: String = "",
+    val ttsResourceId: String = ""
 )
 
 /**
@@ -42,18 +44,26 @@ data class SpeechProviderConfig(
     val ttsDefaultModel: String,
     val ttsModels: List<String>,
     val requiresAppId: Boolean = false,  // 火山引擎需要
-    val requiresCluster: Boolean = false // 火山引擎 TTS 需要
+    val requiresCluster: Boolean = false, // 保留旧字段兼容
+    val requiresAsrResourceId: Boolean = false,
+    val requiresTtsResourceId: Boolean = false
 ) {
     companion object {
         val VOLCANO = SpeechProviderConfig(
             provider = SpeechProvider.VOLCANO,
             displayName = "火山引擎",
-            asrDefaultModel = "bigmodel",
-            asrModels = listOf("bigmodel", "smallmodel"),
-            ttsDefaultModel = "volcano_tts",
-            ttsModels = listOf("volcano_tts"),
+            asrDefaultModel = "volc.seedasr.sauc.duration",
+            asrModels = listOf(
+                "volc.seedasr.sauc.duration",
+                "volc.seedasr.sauc.concurrent"
+            ),
+            ttsDefaultModel = "seed-tts-2.0",
+            ttsModels = listOf("seed-tts-2.0"),
             requiresAppId = true,
-            requiresCluster = true
+            requiresCluster = false,
+            // 火山这里模型即 Resource ID，不需要额外配置字段
+            requiresAsrResourceId = false,
+            requiresTtsResourceId = false
         )
 
         val BAILIAN = SpeechProviderConfig(

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/asr/AsrTypes.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/asr/AsrTypes.kt
@@ -12,7 +12,8 @@ data class AsrConfig(
     val sampleRate: Int = 16000,
     // 火山引擎特有
     val appId: String = "",
-    val cluster: String = ""
+    val cluster: String = "",
+    val resourceId: String = ""
 )
 
 /**
@@ -43,5 +44,9 @@ interface AsrListener {
  */
 interface AsrEngineFactory {
     val provider: SpeechProvider
-    fun create(config: AsrConfig, listener: AsrListener): AsrEngine
+    fun create(
+        config: AsrConfig,
+        listener: AsrListener,
+        externalPcmMode: Boolean = false
+    ): AsrEngine
 }

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/asr/StreamingVoiceRecognitionManager.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/asr/StreamingVoiceRecognitionManager.kt
@@ -2,6 +2,11 @@ package com.alian.assistant.infrastructure.ai.asr
 
 import android.content.Context
 import android.util.Log
+import com.alian.assistant.data.SettingsManager
+import com.alian.assistant.data.model.SpeechProvider
+import com.alian.assistant.data.model.SpeechProviderConfig
+import com.alian.assistant.infrastructure.ai.asr.bailian.BailianAsrEngine
+import com.alian.assistant.infrastructure.ai.asr.volcano.VolcanoAsrEngine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -10,8 +15,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 /**
- * 基于流式 ASR 引擎的语音识别管理器
- * 支持在线 ASR（DashScope）和本地离线 ASR（Sherpa）自动切换。
+ * 基于统一 ASR 引擎的语音识别管理器
+ * 支持在线服务商（百炼/火山）和本地离线 ASR（Sherpa）自动切换。
  */
 class StreamingVoiceRecognitionManager(
     private val context: Context,
@@ -22,8 +27,9 @@ class StreamingVoiceRecognitionManager(
 ) {
     private val tag = "StreamingVoiceRecognitionManager"
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val settingsManager = SettingsManager(context)
 
-    private var cloudAsrEngine: DashscopeStreamAsrEngine? = null
+    private var cloudAsrEngine: AsrEngine? = null
     private var sherpaRecognizer: SherpaOfflineSpeechRecognizer? = null
 
     private var isListening = false
@@ -132,7 +138,8 @@ class StreamingVoiceRecognitionManager(
         try {
             pendingStartJob?.cancel()
             pendingStartJob = null
-            cloudAsrEngine?.stop()
+            cloudAsrEngine?.release()
+            cloudAsrEngine = null
             sherpaRecognizer?.destroy()
             scope.cancel()
             isListening = false
@@ -152,7 +159,7 @@ class StreamingVoiceRecognitionManager(
             if (!initialized) {
                 Log.w(tag, "离线 ASR 初始化失败")
                 pendingStartJob = null
-                if (offlineAsrAutoFallbackToCloud && apiKey.isNotBlank()) {
+                if (offlineAsrAutoFallbackToCloud && canUseCloudAsr()) {
                     startCloud()
                 } else {
                     isListening = false
@@ -184,7 +191,7 @@ class StreamingVoiceRecognitionManager(
                         pendingStartJob = null
                         if (
                             offlineAsrAutoFallbackToCloud &&
-                            apiKey.isNotBlank() &&
+                            canUseCloudAsr() &&
                             message != "没有录音权限"
                         ) {
                             startCloud()
@@ -208,15 +215,22 @@ class StreamingVoiceRecognitionManager(
     }
 
     private fun startCloud() {
-        if (apiKey.isBlank()) {
+        val runtimeConfig = resolveCloudConfig()
+
+        if (runtimeConfig == null) {
             isListening = false
             activeEngine = ActiveEngine.NONE
-            onErrorCallback?.invoke("在线识别不可用（API Key 为空），且离线识别未成功")
+            onErrorCallback?.invoke("在线识别配置不完整，请检查语音服务商凭证")
             return
         }
 
         try {
-            val listener = object : StreamingAsrEngine.Listener {
+            val listener = object : AsrListener {
+                override fun onPartial(text: String) {
+                    Log.d(tag, "在线 ASR 部分结果: $text")
+                    onPartialResultCallback?.invoke(text)
+                }
+
                 override fun onFinal(text: String) {
                     Log.d(tag, "在线 ASR 最终结果: $text")
                     isListening = false
@@ -225,17 +239,12 @@ class StreamingVoiceRecognitionManager(
                     onResultCallback?.invoke(text)
                 }
 
-                override fun onError(message: String) {
-                    Log.e(tag, "在线 ASR 错误: $message")
+                override fun onError(error: String) {
+                    Log.e(tag, "在线 ASR 错误: $error")
                     isListening = false
                     activeEngine = ActiveEngine.NONE
                     pendingStartJob = null
-                    onErrorCallback?.invoke(message)
-                }
-
-                override fun onPartial(text: String) {
-                    Log.d(tag, "在线 ASR 部分结果: $text")
-                    onPartialResultCallback?.invoke(text)
+                    onErrorCallback?.invoke(error)
                 }
 
                 override fun onStopped() {
@@ -243,13 +252,25 @@ class StreamingVoiceRecognitionManager(
                 }
             }
 
-            cloudAsrEngine = DashscopeStreamAsrEngine(
-                apiKey = apiKey,
-                model = model,
-                context = context,
-                scope = scope,
-                listener = listener
-            )
+            cloudAsrEngine?.release()
+            cloudAsrEngine = when (runtimeConfig.provider) {
+                SpeechProvider.VOLCANO -> VolcanoAsrEngine(
+                    config = runtimeConfig.config,
+                    context = context,
+                    scope = scope,
+                    listener = listener,
+                    externalPcmMode = false
+                )
+
+                SpeechProvider.BAILIAN -> BailianAsrEngine(
+                    config = runtimeConfig.config,
+                    context = context,
+                    scope = scope,
+                    listener = listener,
+                    externalPcmMode = false
+                )
+            }
+
             cloudAsrEngine?.start()
             activeEngine = ActiveEngine.CLOUD
             isListening = cloudAsrEngine?.isRunning == true
@@ -268,5 +289,56 @@ class StreamingVoiceRecognitionManager(
             onErrorCallback?.invoke("启动在线语音识别失败: ${e.message}")
         }
     }
-}
 
+    private data class RuntimeCloudConfig(
+        val provider: SpeechProvider,
+        val config: AsrConfig
+    )
+
+    private fun resolveCloudConfig(): RuntimeCloudConfig? {
+        val settings = settingsManager.settings.value
+        val provider = settings.speechProvider
+        val providerConfig = SpeechProviderConfig.get(provider)
+        val credentials = settingsManager.getSpeechCredentials(provider)
+        val speechModels = settingsManager.getSpeechModels(provider)
+
+        val resolvedApiKey = credentials.apiKey.ifBlank { apiKey }
+        val resolvedModel = speechModels.asrModel.ifEmpty {
+            if (model.isNotBlank()) model else providerConfig.asrDefaultModel
+        }
+        val resolvedResourceId = if (provider == SpeechProvider.VOLCANO) {
+            if (resolvedModel.startsWith("volc.", ignoreCase = true)) resolvedModel else ""
+        } else {
+            credentials.asrResourceId
+        }
+
+        val asrConfig = AsrConfig(
+            apiKey = resolvedApiKey,
+            model = resolvedModel,
+            language = "zh",
+            appId = credentials.appId,
+            cluster = credentials.cluster,
+            resourceId = resolvedResourceId
+        )
+
+        return when (provider) {
+            SpeechProvider.BAILIAN -> {
+                if (asrConfig.apiKey.isBlank()) null else RuntimeCloudConfig(provider, asrConfig)
+            }
+
+            SpeechProvider.VOLCANO -> {
+                if (
+                    asrConfig.apiKey.isBlank() ||
+                    asrConfig.appId.isBlank() ||
+                    asrConfig.resourceId.isBlank()
+                ) {
+                    null
+                } else {
+                    RuntimeCloudConfig(provider, asrConfig)
+                }
+            }
+        }
+    }
+
+    private fun canUseCloudAsr(): Boolean = resolveCloudConfig() != null
+}

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/asr/bailian/BailianAsrEngine.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/asr/bailian/BailianAsrEngine.kt
@@ -704,12 +704,17 @@ class BailianAsrEngineFactory(
 ) : AsrEngineFactory {
     override val provider: SpeechProvider = SpeechProvider.BAILIAN
 
-    override fun create(config: AsrConfig, listener: AsrListener): AsrEngine {
+    override fun create(
+        config: AsrConfig,
+        listener: AsrListener,
+        externalPcmMode: Boolean
+    ): AsrEngine {
         return BailianAsrEngine(
             config = config,
             context = context,
             scope = scope,
-            listener = listener
+            listener = listener,
+            externalPcmMode = externalPcmMode
         )
     }
 }

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/asr/volcano/VolcanoAsrEngine.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/asr/volcano/VolcanoAsrEngine.kt
@@ -3,6 +3,7 @@ package com.alian.assistant.infrastructure.ai.asr.volcano
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.media.AudioFormat
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.alian.assistant.data.model.SpeechProvider
@@ -14,13 +15,13 @@ import com.alian.assistant.infrastructure.ai.asr.AudioCaptureManager
 import com.alian.assistant.infrastructure.ai.asr.ExternalPcmConsumer
 import com.alian.assistant.infrastructure.ai.asr.StreamingAsrEngine
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -28,17 +29,23 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
+import org.json.JSONObject
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.util.Base64
+import java.nio.charset.StandardCharsets
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.zip.GZIPInputStream
 
 /**
- * 火山引擎 ASR 引擎
- * 
- * 基于火山引擎流式语音识别 API 实现
- * WebSocket 端点: wss://openspeech.bytedance.com/api/v2/asr
+ * 火山引擎 ASR（v3）
+ *
+ * 参考文档：
+ * - wss://openspeech.bytedance.com/api/v3/sauc/bigmodel(_nostream/_async)
+ * - Header 鉴权: X-Api-App-Key / X-Api-Access-Key / X-Api-Resource-Id / X-Api-Request-Id
  */
 class VolcanoAsrEngine(
     private val config: AsrConfig,
@@ -50,28 +57,57 @@ class VolcanoAsrEngine(
 
     companion object {
         private const val TAG = "VolcanoAsrEngine"
-        private const val WS_URL = "wss://openspeech.bytedance.com/api/v2/asr"
+
+        private const val WS_URL_BIGMODEL = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel"
+        private const val WS_URL_BIGMODEL_NOSTREAM = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_nostream"
+        private const val WS_URL_BIGMODEL_ASYNC = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async"
+
         private const val SAMPLE_RATE = 16000
         private const val FINAL_RESULT_TIMEOUT_MS = 6000L
+
+        private const val MESSAGE_TYPE_FULL_CLIENT_REQUEST = 0x1
+        private const val MESSAGE_TYPE_AUDIO_ONLY_REQUEST = 0x2
+        private const val MESSAGE_TYPE_FULL_SERVER_RESPONSE = 0x9
+        private const val MESSAGE_TYPE_ERROR = 0xF
+
+        private const val FLAG_NO_SEQUENCE = 0x0
+        private const val FLAG_POS_SEQUENCE = 0x1
+        private const val FLAG_NEG_SEQUENCE = 0x3
+
+        private const val SERIALIZATION_RAW = 0x0
+        private const val SERIALIZATION_JSON = 0x1
+
+        private const val COMPRESSION_NONE = 0x0
+        private const val COMPRESSION_GZIP = 0x1
     }
 
     override val provider: SpeechProvider = SpeechProvider.VOLCANO
 
     private val running = AtomicBoolean(false)
-    private var audioJob: Job? = null
-    private var webSocketJob: Job? = null
+    private val finalDelivered = AtomicBoolean(false)
 
     private var webSocket: WebSocket? = null
-    private var currentText: StringBuilder = StringBuilder()
-    private var finalResult: String = ""
+    private var webSocketJob: Job? = null
+    private var audioJob: Job? = null
+
+    @Volatile
+    private var wsReady = false
+
+    private val prebuffer = ArrayDeque<ByteArray>()
+    private val prebufferLock = Any()
+
+    @Volatile
+    private var audioSequence = 1
+
+    @Volatile
+    private var lastRecognizedText: String = ""
+
+    private var finalResultDeferred: CompletableDeferred<String?>? = null
+    @Volatile
+    private var sessionModelName: String = "bigmodel"
 
     override val isRunning: Boolean
         get() = running.get()
-
-    private val prebuffer = mutableListOf<ByteArray>()
-    private val prebufferLock = Any()
-    @Volatile
-    private var wsReady = false
 
     override fun start() {
         if (running.get()) return
@@ -88,32 +124,69 @@ class VolcanoAsrEngine(
         }
 
         if (config.apiKey.isBlank() || config.appId.isBlank()) {
-            listener.onError("API Key 或 App ID 为空")
+            listener.onError("火山引擎 ASR 凭证不完整：需要 App ID + Access Token")
             return
         }
 
         running.set(true)
-        currentText.clear()
-        finalResult = ""
         wsReady = false
+        audioSequence = 1
+        lastRecognizedText = ""
+        finalDelivered.set(false)
+        finalResultDeferred = null
 
         webSocketJob?.cancel()
         webSocketJob = scope.launch(Dispatchers.IO) {
             try {
                 connectWebSocket()
-
                 if (!externalPcmMode) {
                     startCaptureAndSend()
                 }
             } catch (t: Throwable) {
                 Log.e(TAG, "Failed to start Volcano ASR", t)
-                listener.onError(t.message ?: "语音识别错误")
-                running.set(false)
+                if (running.get()) {
+                    running.set(false)
+                    listener.onError(t.message ?: "语音识别错误")
+                }
             }
         }
     }
 
-    private suspend fun connectWebSocket() = withContext(Dispatchers.IO) {
+    private fun connectWebSocket() {
+        val modelLower = config.model.lowercase()
+        val (wsUrl, modelName) = when {
+            modelLower == "bigmodel_nostream" -> WS_URL_BIGMODEL_NOSTREAM to "bigmodel_nostream"
+            modelLower == "bigmodel_async" -> WS_URL_BIGMODEL_ASYNC to "bigmodel_async"
+            else -> WS_URL_BIGMODEL to "bigmodel"
+        }
+        sessionModelName = modelName
+
+        val requestId = UUID.randomUUID().toString()
+        val resourceId = config.resourceId.ifBlank {
+            if (config.model.startsWith("volc.", ignoreCase = true)) {
+                config.model
+            } else {
+                ""
+            }
+        }
+        if (resourceId.isBlank()) {
+            throw IllegalArgumentException("火山引擎 ASR Resource ID 为空，请选择有效 ASR 模型")
+        }
+        Log.d(
+            TAG,
+            "ASR connect wsUrl=$wsUrl, model=$sessionModelName, resourceId=$resourceId, requestId=$requestId"
+        )
+
+        val request = Request.Builder()
+            .url(wsUrl)
+            .addHeader("X-Api-App-Key", config.appId)
+            .addHeader("X-Api-Access-Key", config.apiKey)
+            .addHeader("X-Api-Resource-Id", resourceId)
+            .addHeader("X-Api-Request-Id", requestId)
+            .addHeader("X-Api-Connect-Id", requestId)
+            .addHeader("X-Api-Sequence", "-1")
+            .build()
+
         val client = OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(0, TimeUnit.SECONDS)
@@ -121,48 +194,70 @@ class VolcanoAsrEngine(
             .pingInterval(30, TimeUnit.SECONDS)
             .build()
 
-        // 构建火山引擎认证参数
-        val authParams = buildAuthParams()
-
-        val request = Request.Builder()
-            .url("$WS_URL?$authParams")
-            .build()
-
         val wsListener = object : WebSocketListener() {
             override fun onOpen(ws: WebSocket, response: Response) {
-                Log.d(TAG, "WebSocket 连接已建立")
-                wsReady = true
-                flushPrebuffer()
-            }
-
-            override fun onMessage(ws: WebSocket, text: String) {
-                handleServerMessage(text)
-            }
-
-            override fun onMessage(ws: WebSocket, bytes: ByteString) {
-                // 火山引擎可能使用二进制消息
-                handleBinaryMessage(bytes.toByteArray())
-            }
-
-            override fun onClosing(ws: WebSocket, code: Int, reason: String) {
-                Log.d(TAG, "WebSocket 正在关闭: code=$code, reason=$reason")
-            }
-
-            override fun onClosed(ws: WebSocket, code: Int, reason: String) {
-                Log.d(TAG, "WebSocket 已关闭: code=$code, reason=$reason")
-                wsReady = false
-                if (running.get()) {
+                Log.d(TAG, "Volcano ASR websocket opened, requestId=$requestId")
+                try {
+                    sendFullClientRequest(ws)
+                    wsReady = true
+                    flushPrebuffer()
+                } catch (t: Throwable) {
+                    Log.e(TAG, "send full request failed", t)
+                    listener.onError("初始化 ASR 会话失败: ${t.message}")
                     running.set(false)
-                    listener.onError("连接已关闭: $reason")
+                    closeWebSocket()
                 }
             }
 
-            override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
-                Log.e(TAG, "WebSocket 连接失败", t)
+            override fun onMessage(ws: WebSocket, bytes: ByteString) {
+                handleBinaryMessage(bytes.toByteArray())
+            }
+
+            override fun onMessage(ws: WebSocket, text: String) {
+                Log.w(TAG, "unexpected text message: ${text.take(200)}")
+                try {
+                    val obj = JSONObject(text)
+                    val message = obj.optString("message", text)
+                    if (message.isNotBlank()) {
+                        listener.onError("ASR 服务错误: $message")
+                    }
+                } catch (_: Throwable) {
+                    listener.onError("ASR 服务错误: $text")
+                }
+            }
+
+            override fun onClosing(ws: WebSocket, code: Int, reason: String) {
+                Log.d(TAG, "websocket closing: code=$code reason=$reason")
+            }
+
+            override fun onClosed(ws: WebSocket, code: Int, reason: String) {
+                Log.d(TAG, "websocket closed: code=$code reason=$reason")
                 wsReady = false
-                if (running.get()) {
+            }
+
+            override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
+                val code = response?.code
+                val logId = response?.header("X-Tt-Logid").orEmpty()
+                val responseText = runCatching { response?.body?.string().orEmpty() }
+                    .getOrNull()
+                    ?.take(500)
+                if (responseText.isNullOrBlank()) {
+                    Log.e(TAG, "websocket failure, code=$code, logId=$logId", t)
+                } else {
+                    Log.e(TAG, "websocket failure, code=$code, logId=$logId, response=$responseText", t)
+                }
+                wsReady = false
+                if (running.get() && !finalDelivered.get()) {
                     running.set(false)
-                    listener.onError("连接失败: ${t.message}")
+                    val detail = buildString {
+                        append("连接失败")
+                        if (code != null) append("($code)")
+                        if (logId.isNotBlank()) append(" [logid=$logId]")
+                        if (!responseText.isNullOrBlank()) append(": $responseText")
+                        else if (!t.message.isNullOrBlank()) append(": ${t.message}")
+                    }
+                    listener.onError(detail)
+                    finalResultDeferred?.complete(null)
                 }
             }
         }
@@ -170,112 +265,221 @@ class VolcanoAsrEngine(
         webSocket = client.newWebSocket(request, wsListener)
     }
 
-    /**
-     * 构建火山引擎认证参数
-     * 火山引擎使用 URL 参数进行认证
-     */
-    private fun buildAuthParams(): String {
-        // 火山引擎 ASR API 认证参数
-        // 参考文档: https://www.volcengine.com/docs/6561/79820
-        val appId = config.appId
-        val token = config.apiKey
-        
-        return "app_id=$appId&token=$token&cluster=${config.cluster.ifEmpty { "volc_asr" }}"
-    }
-
-    private fun handleServerMessage(text: String) {
-        Log.d(TAG, "收到服务端消息: $text")
-        try {
-            // 解析火山引擎 ASR 响应
-            // 响应格式为 JSON
-            val response = org.json.JSONObject(text)
-            
-            val result = response.optJSONObject("result")
-            if (result != null) {
-                val text = result.optString("text", "")
-                val isFinal = result.optBoolean("is_final", false)
-
-                if (isFinal) {
-                    finalResult = text
-                    currentText.append(text)
-                    listener.onFinal(currentText.toString().trim())
-                } else {
-                    listener.onPartial(text)
+    private fun sendFullClientRequest(ws: WebSocket) {
+        val requestJson = JSONObject().apply {
+            put("user", JSONObject().apply {
+                put("uid", "beanbun-android")
+                put("platform", "android")
+            })
+            put("audio", JSONObject().apply {
+                put("format", "pcm")
+                put("codec", "raw")
+                put("rate", SAMPLE_RATE)
+                put("bits", 16)
+                put("channel", 1)
+                if (config.language.isNotBlank()) {
+                    put("language", config.language)
                 }
+            })
+            put("request", JSONObject().apply {
+                put("model_name", sessionModelName)
+                put("enable_itn", true)
+                put("enable_punc", true)
+                put("enable_ddc", false)
+                put("show_utterances", true)
+            })
+        }
+
+        val payload = requestJson.toString().toByteArray(StandardCharsets.UTF_8)
+        val frame = buildAsrFrame(
+            messageType = MESSAGE_TYPE_FULL_CLIENT_REQUEST,
+            specificFlags = FLAG_NO_SEQUENCE,
+            serialization = SERIALIZATION_JSON,
+            compression = COMPRESSION_NONE,
+            sequence = null,
+            payload = payload
+        )
+
+        ws.send(frame.toByteString())
+    }
+
+    private fun handleBinaryMessage(frame: ByteArray) {
+        if (frame.size < 8) {
+            Log.w(TAG, "invalid frame too short: ${frame.size}")
+            return
+        }
+
+        val header = frame[0].toInt() and 0xFF
+        val version = (header ushr 4) and 0x0F
+        val headerSize = (header and 0x0F) * 4
+        if (version != 1 || frame.size < headerSize + 4) {
+            Log.w(TAG, "invalid frame header version=$version headerSize=$headerSize size=${frame.size}")
+            return
+        }
+
+        val byte1 = frame[1].toInt() and 0xFF
+        val messageType = (byte1 ushr 4) and 0x0F
+        val messageFlags = byte1 and 0x0F
+
+        val byte2 = frame[2].toInt() and 0xFF
+        val serialization = (byte2 ushr 4) and 0x0F
+        val compression = byte2 and 0x0F
+
+        var offset = headerSize
+
+        when (messageType) {
+            MESSAGE_TYPE_FULL_SERVER_RESPONSE -> {
+                var sequence: Int? = null
+                if (messageFlags == FLAG_POS_SEQUENCE || messageFlags == FLAG_NEG_SEQUENCE) {
+                    if (frame.size < offset + 4) return
+                    sequence = readInt32BE(frame, offset)
+                    offset += 4
+                }
+
+                if (frame.size < offset + 4) return
+                val payloadSize = readInt32BE(frame, offset)
+                offset += 4
+                if (payloadSize < 0 || frame.size < offset + payloadSize) {
+                    Log.w(TAG, "invalid payload size: $payloadSize")
+                    return
+                }
+
+                val rawPayload = frame.copyOfRange(offset, offset + payloadSize)
+                val payload = try {
+                    when (compression) {
+                        COMPRESSION_GZIP -> ungzip(rawPayload)
+                        else -> rawPayload
+                    }
+                } catch (t: Throwable) {
+                    Log.e(TAG, "decompress payload failed", t)
+                    return
+                }
+
+                if (serialization != SERIALIZATION_JSON) {
+                    Log.w(TAG, "unexpected serialization=$serialization")
+                    return
+                }
+
+                val payloadText = payload.toString(StandardCharsets.UTF_8)
+                val isFinal = messageFlags == 0x2 || messageFlags == FLAG_NEG_SEQUENCE || (sequence ?: 1) < 0
+                handleServerJson(payloadText, isFinal)
             }
 
-            // 检查错误
-            val errorCode = response.optInt("code", 0)
-            if (errorCode != 0) {
-                val errorMsg = response.optString("message", "未知错误")
-                listener.onError("识别错误: $errorMsg (code: $errorCode)")
-                running.set(false)
+            MESSAGE_TYPE_ERROR -> {
+                if (frame.size < offset + 8) return
+                val errorCode = readInt32BE(frame, offset)
+                offset += 4
+                val payloadSize = readInt32BE(frame, offset)
+                offset += 4
+                if (payloadSize < 0 || frame.size < offset + payloadSize) {
+                    listener.onError("ASR 协议错误: invalid error payload")
+                    return
+                }
+                val payload = frame.copyOfRange(offset, offset + payloadSize)
+                val message = payload.toString(StandardCharsets.UTF_8)
+                listener.onError("ASR 服务错误($errorCode): $message")
+                finalResultDeferred?.complete(null)
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "解析服务端消息失败", e)
+
+            else -> {
+                Log.d(TAG, "ignore messageType=$messageType flags=$messageFlags")
+            }
         }
     }
 
-    private fun handleBinaryMessage(data: ByteArray) {
-        // 火山引擎可能使用二进制协议
-        Log.d(TAG, "收到二进制消息，大小: ${data.size}")
-    }
-
-    /**
-     * 发送音频数据到火山引擎
-     */
-    private fun sendAudioData(pcm: ByteArray) {
-        if (!wsReady || webSocket == null) return
-
+    private fun handleServerJson(payloadText: String, isFinalFrame: Boolean) {
         try {
-            // 火山引擎 ASR 使用特定的二进制协议格式
-            // 格式: header (11 bytes) + payload
-            val header = buildFrameHeader(pcm.size, sequenceNumber = 0, payloadType = 1)
-            val frame = ByteBuffer.allocate(header.size + pcm.size)
-                .order(ByteOrder.LITTLE_ENDIAN)
-                .put(header)
-                .put(pcm)
-                .array()
+            val response = JSONObject(payloadText)
+            val statusCode = when {
+                response.has("status_code") -> response.optInt("status_code")
+                response.has("code") -> response.optInt("code")
+                else -> 20000000
+            }
 
-            webSocket?.send(frame.toByteString())
-        } catch (e: Exception) {
-            Log.e(TAG, "发送音频数据失败", e)
+            if (statusCode != 0 && statusCode != 20000000) {
+                val message = response.optString("message", "未知错误")
+                listener.onError("ASR 错误($statusCode): $message")
+                finalResultDeferred?.complete(null)
+                return
+            }
+
+            val resultObj = response.optJSONObject("result")
+            val text = resultObj?.optString("text", "")?.trim().orEmpty()
+            if (text.isNotEmpty()) {
+                lastRecognizedText = text
+            }
+
+            if (isFinalFrame) {
+                if (finalDelivered.compareAndSet(false, true)) {
+                    listener.onFinal(lastRecognizedText)
+                }
+                finalResultDeferred?.complete(lastRecognizedText)
+            } else if (text.isNotEmpty()) {
+                listener.onPartial(text)
+            }
+        } catch (t: Throwable) {
+            Log.e(TAG, "parse response json failed: $payloadText", t)
         }
     }
 
-    /**
-     * 构建火山引擎音频帧头
-     */
-    private fun buildFrameHeader(payloadSize: Int, sequenceNumber: Int, payloadType: Int): ByteArray {
-        // 火山引擎音频帧格式
-        // 参考文档: https://www.volcengine.com/docs/6561/79820
-        val buffer = ByteBuffer.allocate(11)
-            .order(ByteOrder.LITTLE_ENDIAN)
-        
-        // Protocol version (1 byte)
-        buffer.put(0x01)
-        // Header size (2 bytes)
-        buffer.putShort(11)
-        // Payload type (1 byte): 1 = audio
-        buffer.put(payloadType.toByte())
-        // Payload size (4 bytes)
-        buffer.putInt(payloadSize)
-        // Sequence number (4 bytes)
-        buffer.putInt(sequenceNumber)
+    private fun sendAudioFrame(pcm: ByteArray, isFinal: Boolean) {
+        if (!wsReady) return
+        val ws = webSocket ?: return
 
-        return buffer.array()
+        val seq = if (isFinal) -audioSequence else audioSequence
+        audioSequence += 1
+
+        val frame = buildAsrFrame(
+            messageType = MESSAGE_TYPE_AUDIO_ONLY_REQUEST,
+            specificFlags = if (isFinal) FLAG_NEG_SEQUENCE else FLAG_POS_SEQUENCE,
+            serialization = SERIALIZATION_RAW,
+            compression = COMPRESSION_NONE,
+            sequence = seq,
+            payload = pcm
+        )
+
+        ws.send(frame.toByteString())
+    }
+
+    private fun buildAsrFrame(
+        messageType: Int,
+        specificFlags: Int,
+        serialization: Int,
+        compression: Int,
+        sequence: Int?,
+        payload: ByteArray
+    ): ByteArray {
+        val baseHeader = byteArrayOf(
+            ((1 shl 4) or 1).toByte(),
+            ((messageType shl 4) or (specificFlags and 0x0F)).toByte(),
+            ((serialization shl 4) or (compression and 0x0F)).toByte(),
+            0x00
+        )
+
+        val total = baseHeader.size + (if (sequence != null) 4 else 0) + 4 + payload.size
+        return ByteBuffer.allocate(total)
+            .order(ByteOrder.BIG_ENDIAN)
+            .put(baseHeader)
+            .apply {
+                if (sequence != null) {
+                    putInt(sequence)
+                }
+                putInt(payload.size)
+                put(payload)
+            }
+            .array()
     }
 
     private fun flushPrebuffer() {
-        val flushed: List<ByteArray>
+        val toFlush = mutableListOf<ByteArray>()
         synchronized(prebufferLock) {
-            flushed = prebuffer.toList()
-            prebuffer.clear()
+            while (prebuffer.isNotEmpty()) {
+                toFlush.add(prebuffer.removeFirst())
+            }
         }
-        flushed.forEach { sendAudioData(it) }
+        toFlush.forEach { sendAudioFrame(it, isFinal = false) }
     }
 
-    // ========== ExternalPcmConsumer ==========
     override fun appendPcm(pcm: ByteArray, sampleRate: Int, channels: Int) {
         if (!running.get()) return
         if (sampleRate != SAMPLE_RATE || channels != 1) return
@@ -287,29 +491,19 @@ class VolcanoAsrEngine(
         }
 
         if (!wsReady) {
-            synchronized(prebufferLock) { prebuffer.add(pcm.copyOf()) }
-        } else {
-            flushPrebuffer()
-            sendAudioData(pcm)
+            synchronized(prebufferLock) {
+                prebuffer.addLast(pcm.copyOf())
+            }
+            return
         }
+
+        flushPrebuffer()
+        sendAudioFrame(pcm, isFinal = false)
     }
 
     override fun commit() {
-        // 火山引擎 ASR 使用 VAD 自动判断结束
-        // 发送结束帧
-        if (wsReady && webSocket != null) {
-            try {
-                val endFrame = buildEndFrame()
-                webSocket?.send(endFrame.toByteString())
-            } catch (e: Exception) {
-                Log.e(TAG, "发送结束帧失败", e)
-            }
-        }
-    }
-
-    private fun buildEndFrame(): ByteArray {
-        // 构建结束帧
-        return buildFrameHeader(0, sequenceNumber = -1, payloadType = 0)
+        if (!running.get()) return
+        sendAudioFrame(ByteArray(0), isFinal = true)
     }
 
     override fun stop() {
@@ -317,25 +511,35 @@ class VolcanoAsrEngine(
         running.set(false)
 
         scope.launch(Dispatchers.IO) {
+            val resultDeferred = CompletableDeferred<String?>()
+            finalResultDeferred = resultDeferred
+
             try {
                 listener.onStopped()
 
-                audioJob?.cancel()
-                audioJob?.join()
+                try {
+                    audioJob?.cancel()
+                    audioJob?.join()
+                } catch (t: Throwable) {
+                    Log.w(TAG, "cancel audio job failed", t)
+                }
                 audioJob = null
 
-                commit()
-
-                // 等待最终结果
-                delay(500)
-
-                if (finalResult.isEmpty() && currentText.isNotEmpty()) {
-                    listener.onFinal(currentText.toString().trim())
+                if (wsReady) {
+                    commit()
                 }
 
+                val finalText = withTimeoutOrNull(FINAL_RESULT_TIMEOUT_MS) {
+                    resultDeferred.await()
+                } ?: lastRecognizedText
+
+                if (finalDelivered.compareAndSet(false, true)) {
+                    listener.onFinal(finalText)
+                }
             } catch (t: Throwable) {
                 Log.w(TAG, "stop cleanup failed", t)
             } finally {
+                finalResultDeferred = null
                 closeWebSocket()
             }
         }
@@ -349,9 +553,9 @@ class VolcanoAsrEngine(
     private fun closeWebSocket() {
         wsReady = false
         try {
-            webSocket?.close(1000, "正常关闭")
-        } catch (e: Exception) {
-            Log.w(TAG, "关闭 WebSocket 失败", e)
+            webSocket?.close(1000, "normal")
+        } catch (t: Throwable) {
+            Log.w(TAG, "close websocket failed", t)
         }
         webSocket = null
     }
@@ -362,8 +566,8 @@ class VolcanoAsrEngine(
             val audioManager = AudioCaptureManager(
                 context = context,
                 sampleRate = SAMPLE_RATE,
-                channelConfig = android.media.AudioFormat.CHANNEL_IN_MONO,
-                audioFormat = android.media.AudioFormat.ENCODING_PCM_16BIT,
+                channelConfig = AudioFormat.CHANNEL_IN_MONO,
+                audioFormat = AudioFormat.ENCODING_PCM_16BIT,
                 chunkMillis = 100
             )
 
@@ -381,10 +585,9 @@ class VolcanoAsrEngine(
                     if (!running.get()) return@collect
 
                     try {
-                        val amplitude = calculateNormalizedAmplitude(audioChunk)
-                        listener.onAmplitude(amplitude)
+                        listener.onAmplitude(calculateNormalizedAmplitude(audioChunk))
                     } catch (t: Throwable) {
-                        Log.w(TAG, "计算振幅失败", t)
+                        Log.w(TAG, "notify amplitude failed", t)
                     }
 
                     if (!vadResult.isSpeech) {
@@ -399,17 +602,38 @@ class VolcanoAsrEngine(
                     }
 
                     if (!wsReady) {
-                        synchronized(prebufferLock) { prebuffer.add(audioChunk.copyOf()) }
+                        synchronized(prebufferLock) {
+                            prebuffer.addLast(audioChunk.copyOf())
+                        }
                     } else {
                         flushPrebuffer()
-                        sendAudioData(audioChunk)
+                        sendAudioFrame(audioChunk, isFinal = false)
                     }
                 }
             } catch (t: Throwable) {
                 if (t !is CancellationException) {
-                    Log.e(TAG, "音频采集失败", t)
+                    Log.e(TAG, "capture failed", t)
                     listener.onError("音频采集失败: ${t.message}")
                 }
+            }
+        }
+    }
+
+    private fun readInt32BE(bytes: ByteArray, offset: Int): Int {
+        return ByteBuffer.wrap(bytes, offset, 4).order(ByteOrder.BIG_ENDIAN).int
+    }
+
+    private fun ungzip(data: ByteArray): ByteArray {
+        ByteArrayInputStream(data).use { bis ->
+            GZIPInputStream(bis).use { gis ->
+                val out = ByteArrayOutputStream()
+                val buffer = ByteArray(4096)
+                while (true) {
+                    val read = gis.read(buffer)
+                    if (read <= 0) break
+                    out.write(buffer, 0, read)
+                }
+                return out.toByteArray()
             }
         }
     }
@@ -442,12 +666,17 @@ class VolcanoAsrEngineFactory(
 ) : AsrEngineFactory {
     override val provider: SpeechProvider = SpeechProvider.VOLCANO
 
-    override fun create(config: AsrConfig, listener: AsrListener): AsrEngine {
+    override fun create(
+        config: AsrConfig,
+        listener: AsrListener,
+        externalPcmMode: Boolean
+    ): AsrEngine {
         return VolcanoAsrEngine(
             config = config,
             context = context,
             scope = scope,
-            listener = listener
+            listener = listener,
+            externalPcmMode = externalPcmMode
         )
     }
 }

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/provider/SpeechProviderManager.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/provider/SpeechProviderManager.kt
@@ -121,13 +121,24 @@ class SpeechProviderManager(
         val credentials = settingsManager.getSpeechCredentials(provider)
         val models = settingsManager.settings.value.speechModels[provider] ?: SpeechModels()
         val providerConfig = SpeechProviderConfig.get(provider)
+        val resolvedModel = models.asrModel.ifEmpty { providerConfig.asrDefaultModel }
+        val resolvedResourceId = when (provider) {
+            // 火山模式下，模型即 Resource ID，忽略历史凭证字段，避免旧值污染
+            SpeechProvider.VOLCANO -> if (resolvedModel.startsWith("volc.", ignoreCase = true)) {
+                resolvedModel
+            } else {
+                ""
+            }
+            SpeechProvider.BAILIAN -> credentials.asrResourceId
+        }
 
         return AsrConfig(
             apiKey = credentials.apiKey,
-            model = models.asrModel.ifEmpty { providerConfig.asrDefaultModel },
+            model = resolvedModel,
             language = "zh",
             appId = credentials.appId,
-            cluster = credentials.cluster
+            cluster = credentials.cluster,
+            resourceId = resolvedResourceId
         )
     }
 
@@ -139,15 +150,26 @@ class SpeechProviderManager(
         val settings = settingsManager.settings.value
         val models = settings.speechModels[provider] ?: SpeechModels()
         val providerConfig = SpeechProviderConfig.get(provider)
+        val resolvedModel = models.ttsModel.ifEmpty { providerConfig.ttsDefaultModel }
+        val resolvedResourceId = when (provider) {
+            // 火山模式下，模型即 Resource ID，忽略历史凭证字段，避免旧值污染
+            SpeechProvider.VOLCANO -> if (resolvedModel.startsWith("seed-tts-", ignoreCase = true)) {
+                resolvedModel
+            } else {
+                ""
+            }
+            SpeechProvider.BAILIAN -> credentials.ttsResourceId
+        }
 
         return TtsConfig(
             apiKey = credentials.apiKey,
-            model = models.ttsModel.ifEmpty { providerConfig.ttsDefaultModel },
+            model = resolvedModel,
             voice = settings.ttsVoice,
             speed = settings.ttsSpeed,
             volume = settings.volume,
             appId = credentials.appId,
-            cluster = credentials.cluster
+            cluster = credentials.cluster,
+            resourceId = resolvedResourceId
         )
     }
 
@@ -177,6 +199,20 @@ class SpeechProviderManager(
      */
     fun requiresCluster(provider: SpeechProvider): Boolean {
         return SpeechProviderConfig.get(provider).requiresCluster
+    }
+
+    /**
+     * 检查服务商是否需要 ASR Resource ID
+     */
+    fun requiresAsrResourceId(provider: SpeechProvider): Boolean {
+        return SpeechProviderConfig.get(provider).requiresAsrResourceId
+    }
+
+    /**
+     * 检查服务商是否需要 TTS Resource ID
+     */
+    fun requiresTtsResourceId(provider: SpeechProvider): Boolean {
+        return SpeechProviderConfig.get(provider).requiresTtsResourceId
     }
 
     companion object {

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/provider/VoicePresetManager.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/provider/VoicePresetManager.kt
@@ -127,145 +127,464 @@ class BailianVoicePresetProvider : VoicePresetProvider {
 class VolcanoVoicePresetProvider : VoicePresetProvider {
     override val provider: SpeechProvider = SpeechProvider.VOLCANO
 
-    // 火山引擎支持的音色列表
-    // 参考: https://www.volcengine.com/docs/6561/97465
+    private fun preset(
+        name: String,
+        voiceParam: String,
+        trait: String,
+        age: String,
+        language: String,
+        category: VoiceCategory,
+        avatarUrl: String,
+        auditionUrl: String
+    ): VoicePreset {
+        return VoicePreset(
+            name = name,
+            voiceParam = voiceParam,
+            trait = trait,
+            age = age,
+            language = language,
+            supportsSSML = false,
+            supportsInstruct = false,
+            supportsTimestamp = false,
+            category = category,
+            avatarUrl = avatarUrl,
+            auditionUrl = auditionUrl,
+            provider = SpeechProvider.VOLCANO
+        )
+    }
+
+    // 火山引擎音色列表（seed-tts-2.0）
     private val presetList: List<VoicePreset> by lazy {
         listOf(
-            // 通用音色
-            VoicePreset(
-                name = "天美",
-                voiceParam = "zh_female_tianmei_moon_bigtts",
-                trait = "温柔甜美女声",
-                age = "20~30岁",
+            preset(
+                name = "小何 2.0",
+                voiceParam = "zh_female_xiaohe_uranus_bigtts",
+                trait = "声线甜美有活力的妹妹，活泼开朗，笑容明媚。",
+                age = "青年",
                 language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
                 category = VoiceCategory.VOICE_ASSISTANT,
-                provider = SpeechProvider.VOLCANO
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/小何.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_xiaohe_uranus_bigtts.mp3"
             ),
-            VoicePreset(
-                name = "梓梓",
-                voiceParam = "zh_female_zhimai_emo_moon_bigtts",
-                trait = "知性温柔女声",
-                age = "25~35岁",
-                language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
+            preset(
+                name = "Vivi 2.0",
+                voiceParam = "zh_female_vv_uranus_bigtts",
+                trait = "语调平稳、咬字柔和、自带治愈安抚力的女声音色",
+                age = "青年",
+                language = "中/日/印尼/西语",
                 category = VoiceCategory.VOICE_ASSISTANT,
-                provider = SpeechProvider.VOLCANO
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/vivi_v2.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_vv_uranus_bigtts.wav"
             ),
-            VoicePreset(
-                name = "泽泽",
-                voiceParam = "zh_male_zhiboshuangkuai_moon_bigtts",
-                trait = "阳光开朗男声",
-                age = "20~30岁",
+            preset(
+                name = "撒娇学妹 2.0",
+                voiceParam = "zh_female_sajiaoxuemei_uranus_bigtts",
+                trait = "嗲甜软萌的可爱妹妹，灵动娇气，活泼讨喜",
+                age = "青年",
                 language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
-                category = VoiceCategory.VOICE_ASSISTANT,
-                provider = SpeechProvider.VOLCANO
-            ),
-            VoicePreset(
-                name = "燃燃",
-                voiceParam = "zh_female_chunhou_moon_bigtts",
-                trait = "清纯甜美女声",
-                age = "18~25岁",
-                language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
                 category = VoiceCategory.SOCIAL_COMPANION,
-                provider = SpeechProvider.VOLCANO
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/撒娇学妹.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_sajiaoxuemei_uranus_bigtts.mp3"
             ),
-            VoicePreset(
-                name = "炀炀",
-                voiceParam = "zh_male_chunhou_moon_bigtts",
-                trait = "温暖磁性男声",
-                age = "25~35岁",
+            preset(
+                name = "邻家女孩 2.0",
+                voiceParam = "zh_female_linjianvhai_uranus_bigtts",
+                trait = "软糯温柔的邻家女孩，低调内敛，耐心亲和",
+                age = "青年",
                 language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/邻家女孩.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_linjianvhai_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "暖阳女声 2.0",
+                voiceParam = "zh_female_kefunvsheng_uranus_bigtts",
+                trait = "开朗温柔的客服，阳光热情，服务贴心细致",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.CUSTOMER_SERVICE,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/暖阳女声.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_kefunvsheng_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "少年梓辛/Brayan 2.0",
+                voiceParam = "zh_male_shaonianzixin_uranus_bigtts",
+                trait = "少年感十足的清爽男生，温柔亲切，阳光开朗",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/少年梓辛.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_shaonianzixin_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "佩奇猪 2.0",
+                voiceParam = "zh_female_peiqi_uranus_bigtts",
+                trait = "活泼童趣，天真烂漫，可爱治愈",
+                age = "儿童",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/佩奇猪.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_peiqi_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "刘飞 2.0",
+                voiceParam = "zh_male_liufei_uranus_bigtts",
+                trait = "逻辑清晰、理性稳重的男性",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/刘飞.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_liufei_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "知性灿灿 2.0",
+                voiceParam = "zh_female_cancan_uranus_bigtts",
+                trait = "语气温柔舒缓，软糯但有善解人意的治愈系少女音",
+                age = "青年",
+                language = "中文",
                 category = VoiceCategory.SOCIAL_COMPANION,
-                provider = SpeechProvider.VOLCANO
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/灿灿.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_cancan_uranus_bigtts.mp3"
             ),
-            // 客服音色
-            VoicePreset(
-                name = " Latina",
-                voiceParam = "zh_female_qingxinwenrou_moon_bigtts",
-                trait = "清新温柔女声",
-                age = "20~30岁",
+            preset(
+                name = "儒雅逸辰 2.0",
+                voiceParam = "zh_male_ruyayichen_uranus_bigtts",
+                trait = "低沉优雅的稳重青年，温柔成熟，儒雅得体",
+                age = "青年",
                 language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
-                category = VoiceCategory.CUSTOMER_SERVICE,
-                provider = SpeechProvider.VOLCANO
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/儒雅逸辰.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_ruyayichen_uranus_bigtts.mp3"
             ),
-            VoicePreset(
-                name = "哲哲",
-                voiceParam = "zh_male_chenwen_moon_bigtts",
-                trait = "沉稳专业男声",
-                age = "30~40岁",
+            preset(
+                name = "流畅女声 2.0",
+                voiceParam = "zh_female_liuchangnv_uranus_bigtts",
+                trait = "温暖爽朗的小妹，阳光热情，性格直爽好相处",
+                age = "青年",
                 language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
-                category = VoiceCategory.CUSTOMER_SERVICE,
-                provider = SpeechProvider.VOLCANO
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/流畅女声.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_liuchangnv_uranus_bigtts.mp3"
             ),
-            // 有声书音色
-            VoicePreset(
-                name = "童童",
-                voiceParam = "zh_female_tongxin_moon_bigtts",
-                trait = "童声女声",
-                age = "6~12岁",
+            preset(
+                name = "魅力女友 2.0",
+                voiceParam = "zh_female_meilinvyou_uranus_bigtts",
+                trait = "性感妩媚的御姐，成熟有魅力，风情十足",
+                age = "青年",
                 language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
-                category = VoiceCategory.CHILDREN,
-                provider = SpeechProvider.VOLCANO
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/魅力女友.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_meilinvyou_uranus_bigtts.mp3"
             ),
-            VoicePreset(
-                name = "讲故事女声",
-                voiceParam = "zh_female_storytelling_moon_bigtts",
-                trait = "故事讲述女声",
-                age = "25~35岁",
+            preset(
+                name = "鸡汤女 2.0",
+                voiceParam = "zh_female_jitangnv_uranus_bigtts",
+                trait = "声音治愈的知心姐姐，温柔体贴，擅长倾听与理解",
+                age = "青年",
                 language = "中文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/鸡汤女.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_jitangnv_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "黑猫侦探社咪仔 2.0",
+                voiceParam = "zh_female_mizai_uranus_bigtts",
+                trait = "声线稳重优雅的知心姐姐，温暖亲和，善于陪伴",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/黑猫侦探社咪仔.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_mizai_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "大壹 2.0",
+                voiceParam = "zh_male_dayi_uranus_bigtts",
+                trait = "历经世事的沉稳大叔，果敢可靠，让人安心信赖",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/大壹.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_dayi_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "Tina老师 2.0",
+                voiceParam = "zh_female_yingyujiaoxue_uranus_bigtts",
+                trait = "磁性知性的青年讲师，温柔耐心，专业靠谱",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/Tina老师.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_yingyujiaoxue_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "猴哥 2.0",
+                voiceParam = "zh_male_sunwukong_uranus_bigtts",
+                trait = "傲娇不羁的猴哥，声线经典灵动，一秒梦回西游",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/猴哥.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_sunwukong_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "爽快思思 2.0",
+                voiceParam = "zh_female_shuangkuaisisi_uranus_bigtts",
+                trait = "温暖直爽的邻家小妹，阳光热情，相处轻松自在",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/爽快思思.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_shuangkuaisisi_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "甜美桃子 2.0",
+                voiceParam = "zh_female_tianmeitaozi_uranus_bigtts",
+                trait = "俏皮元气女生，开朗外向，自带活跃气氛的感染力",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/甜美桃子.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_tianmeitaozi_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "清新女声 2.0",
+                voiceParam = "zh_female_qingxinnvsheng_uranus_bigtts",
+                trait = "气质出众的旗袍美人兼职场精英，明媚大方，魅力十足",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/清新女声.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_qingxinnvsheng_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "魅力苏菲 2.0",
+                voiceParam = "zh_male_sophie_uranus_bigtts",
+                trait = "高冷御姐，外表疏离难亲近，内心却细腻柔软",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/魅力苏菲.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_sophie_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "小天 2.0",
+                voiceParam = "zh_male_taocheng_uranus_bigtts",
+                trait = "眉目清朗男大，清澈温润有朝气，开朗真诚。",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/小天.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_taocheng_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "云舟 2.0",
+                voiceParam = "zh_male_m191_uranus_bigtts",
+                trait = "声音磁性的男生，成熟理性，做事有条理，让人信赖。",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/云舟.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_m191_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "儿童绘本 2.0",
+                voiceParam = "zh_female_xiaoxue_uranus_bigtts",
+                trait = "清甜讲述者，充满童趣与耐心，为孩子编织美好梦境",
+                age = "青年",
+                language = "中文",
                 category = VoiceCategory.AUDIOBOOK_ADULT,
-                provider = SpeechProvider.VOLCANO
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/儿童绘本.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_xiaoxue_uranus_bigtts.mp3"
             ),
-            // 英文音色
-            VoicePreset(
-                name = "Emma",
-                voiceParam = "en_female_amy_moon_bigtts",
-                trait = "美式英文女声",
-                age = "20~30岁",
-                language = "英文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
-                category = VoiceCategory.INTERNATIONAL,
-                provider = SpeechProvider.VOLCANO
+            preset(
+                name = "甜美小源 2.0",
+                voiceParam = "zh_female_tianmeixiaoyuan_uranus_bigtts",
+                trait = "声线明亮甜美的专业客服，亲切耐心，服务细致周到",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/甜美小源.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_tianmeixiaoyuan_uranus_bigtts.mp3"
             ),
-            VoicePreset(
-                name = "James",
-                voiceParam = "en_male_narration_moon_bigtts",
-                trait = "美式英文男声",
-                age = "30~40岁",
-                language = "英文",
-                supportsSSML = false,
-                supportsInstruct = false,
-                supportsTimestamp = false,
+            preset(
+                name = "轻盈朵朵 2.0",
+                voiceParam = "saturn_zh_female_qingyingduoduo_cs_tob",
+                trait = "知性活力的女老师，谦虚包容，平易近人",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.CUSTOMER_SERVICE,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/轻盈朵朵.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/ICL_zh_female_qingyingduoduo_cs_tob.mp3"
+            ),
+            preset(
+                name = "Stokie",
+                voiceParam = "en_female_stokie_uranus_bigtts",
+                trait = "音色甜美温柔的邻家姐姐，性格亲切细腻，相处时让人倍感安心。",
+                age = "青年",
+                language = "英语（美式）",
                 category = VoiceCategory.INTERNATIONAL,
-                provider = SpeechProvider.VOLCANO
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/Stokie.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/en_female_stokie_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "Dacey",
+                voiceParam = "en_female_dacey_uranus_bigtts",
+                trait = "温暖声的直爽小妹，性格阳光热情，相处爽快。",
+                age = "青年",
+                language = "英语（美式）",
+                category = VoiceCategory.INTERNATIONAL,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/Dacey.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/en_female_dacey_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "Tim",
+                voiceParam = "en_male_tim_uranus_bigtts",
+                trait = "声线温润干净的儒雅青年，待人温柔又暖心，自带治愈人心的力量。",
+                age = "青年",
+                language = "英语（美式）",
+                category = VoiceCategory.INTERNATIONAL,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/TIM2.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/en_male_tim_uranus_bigtts.mp3"
+            ),
+            preset(
+                name = "流畅女声",
+                voiceParam = "zh_female_santongyongns_saturn_bigtts",
+                trait = "语调顺滑自然、咬字利落不拖沓、适配多种场景的百搭女声音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/流畅女声.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/流畅女声.wav"
+            ),
+            preset(
+                name = "魅力女友",
+                voiceParam = "zh_female_meilinvyou_saturn_bigtts",
+                trait = "嗲软轻飘的轻熟美人，妩媚有耐心，温柔勾人。",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/魅力女友_v2.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_meilinvyou_saturn_bigtts.wav"
+            ),
+            preset(
+                name = "黑猫侦探社咪仔",
+                voiceParam = "zh_female_mizai_saturn_bigtts",
+                trait = "语调沉稳、咬字扎实、自带踏实和包容感的女声音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/黑猫侦探社咪仔.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_mizai_saturn_bigtts.wav"
+            ),
+            preset(
+                name = "天才同桌",
+                voiceParam = "saturn_zh_male_tiancaitongzhuo_tob",
+                trait = "语气明快利落、咬字清晰带活力、聪明机敏又毒舌的少年音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SOCIAL_COMPANION,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/天才同桌.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/saturn_zh_male_tiancaitongzhuo_tob.wav"
+            ),
+            preset(
+                name = "知性灿灿",
+                voiceParam = "saturn_zh_female_cancan_tob",
+                trait = "语气温柔平缓、带有些许软绵感却又善解人意的少女音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SOCIAL_COMPANION,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/灿灿.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/saturn_zh_female_cancan_tob.wav"
+            ),
+            preset(
+                name = "鸡汤女",
+                voiceParam = "zh_female_jitangnv_saturn_bigtts",
+                trait = "语气轻软、尾音轻落、带有自然呼吸感且十分亲切的女声音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/鸡汤女.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_jitangnv_saturn_bigtts.wav"
+            ),
+            preset(
+                name = "大壹",
+                voiceParam = "zh_male_dayi_saturn_bigtts",
+                trait = "语气沉稳有力、咬字清晰厚重、自带可靠安全感的男声音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/大壹.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_dayi_saturn_bigtts.wav"
+            ),
+            preset(
+                name = "儿童绘本",
+                voiceParam = "zh_female_xueayi_saturn_bigtts",
+                trait = "温柔又有力量的音色，陪孩子在故事里勇敢探索！",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.VOICE_ASSISTANT,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/儿童绘本.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_female_xueayi_saturn_bigtts.mp3"
+            ),
+            preset(
+                name = "温婉珊珊 2.0",
+                voiceParam = "saturn_zh_female_wenwanshanshan_cs_tob",
+                trait = "温婉治愈的体贴女生，自带亲和力",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.CUSTOMER_SERVICE,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/温婉珊珊.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/ICL_zh_female_wenwanshanshan_cs_tob.mp3"
+            ),
+            preset(
+                name = "热情艾娜 2.0",
+                voiceParam = "saturn_zh_female_reqingaina_cs_tob",
+                trait = "热情阳光的数学教师，气质优雅飒爽",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.CUSTOMER_SERVICE,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/热情艾娜.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/ICL_zh_female_reqingaina_cs_tob.mp3"
+            ),
+            preset(
+                name = "可爱女生",
+                voiceParam = "saturn_zh_female_keainvsheng_tob",
+                trait = "可爱的妹妹，性格活泼，举动讨喜。",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SOCIAL_COMPANION,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/可爱女生.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/saturn_zh_female_keainvsheng_tob.wav"
+            ),
+            preset(
+                name = "爽朗少年",
+                voiceParam = "saturn_zh_male_shuanglangshaonian_tob",
+                trait = "语气洪亮开阔、咬字干脆爽朗、阳光率真不扭捏的少年音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SOCIAL_COMPANION,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/爽朗少年.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/saturn_zh_male_shuanglangshaonian_tob.wav"
+            ),
+            preset(
+                name = "调皮公主",
+                voiceParam = "saturn_zh_female_tiaopigongzhu_tob",
+                trait = "语调灵动跳脱、尾音带娇俏、古灵精怪爱撒娇的少女音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SOCIAL_COMPANION,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/调皮公主.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/saturn_zh_female_tiaopigongzhu_tob.wav"
+            ),
+            preset(
+                name = "儒雅逸辰",
+                voiceParam = "zh_male_ruyayichen_saturn_bigtts",
+                trait = "语气温润有礼、咬字文雅舒缓、自带书卷气的儒雅男声音色",
+                age = "青年",
+                language = "中文",
+                category = VoiceCategory.SHORT_VIDEO,
+                avatarUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/avatar/儒雅逸辰.png",
+                auditionUrl = "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_hz_ihsph/ljhwZthlaukjlkulzlp/portal/bigtts/zh_male_ruyayichen_saturn_bigtts.wav"
             )
         )
     }
@@ -281,6 +600,7 @@ class VolcanoVoicePresetProvider : VoicePresetProvider {
     }
 
     override fun getDefaultVoice(): VoicePreset {
-        return presetList.first()
+        return presetList.find { it.voiceParam == "zh_female_shuangkuaisisi_uranus_bigtts" }
+            ?: presetList.first()
     }
 }

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/tts/HybridTtsClient.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/tts/HybridTtsClient.kt
@@ -2,6 +2,11 @@ package com.alian.assistant.infrastructure.ai.tts
 
 import android.content.Context
 import android.util.Log
+import com.alian.assistant.data.SettingsManager
+import com.alian.assistant.data.model.SpeechProvider
+import com.alian.assistant.data.model.SpeechProviderConfig
+import com.alian.assistant.infrastructure.ai.tts.bailian.BailianTtsEngine
+import com.alian.assistant.infrastructure.ai.tts.volcano.VolcanoTtsEngine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -13,7 +18,7 @@ import kotlinx.coroutines.withContext
 /**
  * 统一 TTS 客户端：
  * 1. 离线 TTS 开启时优先使用 sherpa-onnx
- * 2. 离线失败可按配置回退在线 CosyVoice
+ * 2. 离线失败可按配置回退在线 TTS（按语音服务商动态切换）
  */
 class HybridTtsClient(
     private val appContext: Context,
@@ -28,7 +33,11 @@ class HybridTtsClient(
         private const val TAG = "HybridTtsClient"
     }
 
-    private var onlineClient: CosyVoiceTTSClient? = null
+    private val settingsManager = SettingsManager(appContext)
+
+    private var onlineEngine: TtsEngine? = null
+    private var onlineEngineSignature: String = ""
+
     private var offlineClient: SherpaOnnxOfflineTtsClient? = null
 
     private var onAudioDataCallback: ((ByteArray) -> Unit)? = null
@@ -43,6 +52,12 @@ class HybridTtsClient(
 
     @Volatile
     private var offlineStreamingActive = false
+
+    @Volatile
+    private var onlineStreamingActive = false
+
+    @Volatile
+    private var onlineStreamingFinished = true
 
     suspend fun synthesizeAndPlay(text: String, context: Context): Result<Unit> = withContext(Dispatchers.IO) {
         if (text.isBlank()) {
@@ -72,10 +87,15 @@ class HybridTtsClient(
             return@withContext Result.success(Unit)
         }
 
-        val client = ensureOnlineClient()
-            ?: return@withContext Result.failure(IllegalStateException("Online TTS API Key is empty"))
+        val engine = ensureOnlineEngine()
+            ?: return@withContext Result.failure(IllegalStateException("Online TTS 配置不完整"))
 
-        client.startStreamingSession(context)
+        val result = engine.startStreamingSession(context)
+        if (result.isSuccess) {
+            onlineStreamingActive = true
+            onlineStreamingFinished = false
+        }
+        result
     }
 
     fun sendStreamingChunk(chunk: String): Result<Unit> {
@@ -89,9 +109,14 @@ class HybridTtsClient(
             return Result.success(Unit)
         }
 
-        val client = ensureOnlineClient()
-            ?: return Result.failure(IllegalStateException("Online TTS API Key is empty"))
-        return client.sendStreamingChunk(chunk)
+        val engine = ensureOnlineEngine()
+            ?: return Result.failure(IllegalStateException("Online TTS 配置不完整"))
+
+        if (!onlineStreamingActive) {
+            return Result.failure(IllegalStateException("Online streaming session is not active"))
+        }
+
+        return engine.sendStreamingChunk(chunk)
     }
 
     fun finishStreamingSession(): Result<Unit> {
@@ -123,9 +148,19 @@ class HybridTtsClient(
             return Result.success(Unit)
         }
 
-        val client = ensureOnlineClient()
-            ?: return Result.failure(IllegalStateException("Online TTS API Key is empty"))
-        return client.finishStreamingSession()
+        val engine = ensureOnlineEngine()
+            ?: return Result.failure(IllegalStateException("Online TTS 配置不完整"))
+
+        if (!onlineStreamingActive) {
+            return Result.failure(IllegalStateException("Online streaming session is not active"))
+        }
+
+        val result = engine.finishStreamingSession()
+        if (result.isSuccess) {
+            // 已发送 finish，会话完成由服务端事件驱动
+            onlineStreamingActive = false
+        }
+        return result
     }
 
     fun stopStreamingSession() {
@@ -139,7 +174,9 @@ class HybridTtsClient(
             return
         }
 
-        onlineClient?.stopStreamingSession()
+        onlineEngine?.cancelPlayback()
+        onlineStreamingActive = false
+        onlineStreamingFinished = true
     }
 
     fun cancelPlayback() {
@@ -150,33 +187,38 @@ class HybridTtsClient(
         offlineStreamingContext = null
 
         offlineClient?.cancelPlayback()
-        onlineClient?.cancelPlayback()
+
+        onlineEngine?.cancelPlayback()
+        onlineStreamingActive = false
+        onlineStreamingFinished = true
     }
 
     fun isStreamingActive(): Boolean {
         if (offlineTtsEnabled) {
             return offlineStreamingActive || offlineStreamingJob?.isActive == true
         }
-        return onlineClient?.isStreamingActive() == true
+
+        val enginePlaying = onlineEngine?.isCurrentlyPlaying() == true
+        return onlineStreamingActive || !onlineStreamingFinished || enginePlaying
     }
 
     fun isTaskFinished(): Boolean {
         if (offlineTtsEnabled) {
             return !isStreamingActive()
         }
-        return onlineClient?.isTaskFinished() ?: false
+        return !isStreamingActive()
     }
 
     suspend fun isAudioTrackStillPlaying(): Boolean {
         if (offlineTtsEnabled) {
             return offlineClient?.isAudioTrackStillPlaying() == true
         }
-        return onlineClient?.isAudioTrackStillPlaying() ?: false
+        return onlineEngine?.isCurrentlyPlaying() == true
     }
 
     fun isCurrentlyPlaying(): Boolean {
         return offlineClient?.isCurrentlyPlaying() == true ||
-            onlineClient?.isCurrentlyPlaying() == true ||
+            onlineEngine?.isCurrentlyPlaying() == true ||
             offlineStreamingJob?.isActive == true
     }
 
@@ -186,14 +228,13 @@ class HybridTtsClient(
             if (text.isNotBlank()) {
                 offlineStreamingBuffer.append(text)
             }
-        } else {
-            onlineClient?.setStreamingFullText(text)
         }
+        // 在线模式由服务端 session 管理，不需要额外维护全文缓存
     }
 
     fun setOnAudioDataCallback(callback: ((ByteArray) -> Unit)?) {
         onAudioDataCallback = callback
-        onlineClient?.setOnAudioDataCallback(callback)
+        onlineEngine?.setOnAudioDataCallback(callback)
         offlineClient?.setOnAudioDataCallback(callback)
     }
 
@@ -202,8 +243,9 @@ class HybridTtsClient(
         scope.coroutineContext.cancelChildren()
         offlineClient?.release()
         offlineClient = null
-        onlineClient?.cancelPlayback()
-        onlineClient = null
+        onlineEngine?.release()
+        onlineEngine = null
+        onlineEngineSignature = ""
     }
 
     private suspend fun synthesizeWithOffline(text: String, context: Context): Result<Unit> = withContext(Dispatchers.IO) {
@@ -220,25 +262,108 @@ class HybridTtsClient(
     }
 
     private suspend fun synthesizeWithCloud(text: String, context: Context): Result<Unit> = withContext(Dispatchers.IO) {
-        val client = ensureOnlineClient()
-            ?: return@withContext Result.failure(IllegalStateException("Online TTS API Key is empty"))
-        client.synthesizeAndPlay(text, context)
+        val engine = ensureOnlineEngine()
+            ?: return@withContext Result.failure(IllegalStateException("Online TTS 配置不完整"))
+        onlineStreamingFinished = true
+        engine.synthesizeAndPlay(text, context)
     }
 
-    private fun ensureOnlineClient(): CosyVoiceTTSClient? {
-        if (apiKey.isBlank()) return null
-        val cached = onlineClient
-        if (cached != null) return cached
+    private fun ensureOnlineEngine(): TtsEngine? {
+        val runtime = resolveRuntimeOnlineConfig() ?: return null
+        val signature = runtime.signature
 
-        return CosyVoiceTTSClient(
-            apiKey = apiKey,
-            voice = voice,
-            rate = rate,
-            volume = volume
-        ).also {
-            it.setOnAudioDataCallback(onAudioDataCallback)
-            onlineClient = it
+        val cached = onlineEngine
+        if (cached != null && signature == onlineEngineSignature) {
+            return cached
         }
+
+        onlineEngine?.release()
+
+        val newEngine: TtsEngine = when (runtime.provider) {
+            SpeechProvider.BAILIAN -> BailianTtsEngine(runtime.config)
+            SpeechProvider.VOLCANO -> VolcanoTtsEngine(runtime.config)
+        }
+
+        newEngine.setOnAudioDataCallback(onAudioDataCallback)
+        newEngine.setOnPlaybackStateCallback { state ->
+            when (state) {
+                TtsPlaybackState.Completed,
+                is TtsPlaybackState.Error -> {
+                    onlineStreamingFinished = true
+                    onlineStreamingActive = false
+                }
+
+                TtsPlaybackState.Playing -> {
+                    onlineStreamingFinished = false
+                }
+
+                TtsPlaybackState.Idle -> Unit
+            }
+        }
+
+        onlineEngine = newEngine
+        onlineEngineSignature = signature
+        return newEngine
+    }
+
+    private data class RuntimeOnlineConfig(
+        val provider: SpeechProvider,
+        val config: TtsConfig,
+        val signature: String
+    )
+
+    private fun resolveRuntimeOnlineConfig(): RuntimeOnlineConfig? {
+        val settings = settingsManager.settings.value
+        val provider = settings.speechProvider
+        val providerConfig = SpeechProviderConfig.get(provider)
+        val credentials = settingsManager.getSpeechCredentials(provider)
+        val models = settingsManager.getSpeechModels(provider)
+
+        val resolvedApiKey = credentials.apiKey.ifBlank { apiKey }
+        val resolvedModel = models.ttsModel.ifEmpty { providerConfig.ttsDefaultModel }
+        val resolvedResourceId = if (provider == SpeechProvider.VOLCANO) {
+            if (resolvedModel.startsWith("seed-tts-", ignoreCase = true)) resolvedModel else ""
+        } else {
+            credentials.ttsResourceId
+        }
+
+        val ttsConfig = TtsConfig(
+            apiKey = resolvedApiKey,
+            model = resolvedModel,
+            voice = voice,
+            speed = rate,
+            volume = volume,
+            sampleRate = 16000,
+            appId = credentials.appId,
+            cluster = credentials.cluster,
+            resourceId = resolvedResourceId
+        )
+
+        val available = when (provider) {
+            SpeechProvider.BAILIAN -> ttsConfig.apiKey.isNotBlank()
+            SpeechProvider.VOLCANO -> {
+                ttsConfig.apiKey.isNotBlank() &&
+                    ttsConfig.appId.isNotBlank() &&
+                    ttsConfig.resourceId.isNotBlank()
+            }
+        }
+
+        if (!available) {
+            return null
+        }
+
+        val signature = listOf(
+            provider.name,
+            ttsConfig.apiKey,
+            ttsConfig.appId,
+            ttsConfig.resourceId,
+            ttsConfig.model,
+            ttsConfig.voice,
+            ttsConfig.speed,
+            ttsConfig.volume
+        ).joinToString("|")
+
+        return RuntimeOnlineConfig(provider, ttsConfig, signature)
     }
 
     private fun ensureOfflineClient(): SherpaOnnxOfflineTtsClient {

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/tts/TtsTypes.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/tts/TtsTypes.kt
@@ -15,7 +15,8 @@ data class TtsConfig(
     val sampleRate: Int = 16000,
     // 火山引擎特有
     val appId: String = "",
-    val cluster: String = ""
+    val cluster: String = "",
+    val resourceId: String = ""
 )
 
 /**

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/tts/bailian/BailianTtsEngine.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/tts/bailian/BailianTtsEngine.kt
@@ -94,6 +94,7 @@ class BailianTtsEngine(
         private const val SAMPLE_RATE = 16000
         private const val CHANNEL_CONFIG = AudioFormat.CHANNEL_OUT_MONO
         private const val AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT
+        private const val PCM_BYTES_PER_FRAME = 2L
     }
 
     override val provider: SpeechProvider = SpeechProvider.BAILIAN
@@ -113,6 +114,8 @@ class BailianTtsEngine(
     private var currentWebSocket: WebSocket? = null
     private var currentAudioTrack: AudioTrack? = null
     private var isPlaying = false
+    @Volatile
+    private var singleFramesWritten: Long = 0L
 
     // 音频数据回调
     private var onAudioDataCallback: ((ByteArray) -> Unit)? = null
@@ -125,6 +128,8 @@ class BailianTtsEngine(
     private var streamingAudioTrack: AudioTrack? = null
     private var isStreaming = false
     private var streamingTaskId: String = ""
+    @Volatile
+    private var streamingFramesWritten: Long = 0L
 
     // 协议状态
     private enum class ProtocolState {
@@ -149,7 +154,11 @@ class BailianTtsEngine(
     @Volatile
     private var isOldSessionClosed = true
 
-    override fun isCurrentlyPlaying(): Boolean = isPlaying
+    override fun isCurrentlyPlaying(): Boolean {
+        val singlePlaying = hasPendingAudio(currentAudioTrack, singleFramesWritten)
+        val streamPlaying = isStreaming && hasPendingAudio(streamingAudioTrack, streamingFramesWritten)
+        return singlePlaying || streamPlaying
+    }
 
     override fun setOnAudioDataCallback(callback: ((ByteArray) -> Unit)?) {
         onAudioDataCallback = callback
@@ -196,6 +205,7 @@ class BailianTtsEngine(
                 .build()
 
             currentAudioTrack?.play()
+            singleFramesWritten = 0L
             isPlaying = true
             onPlaybackStateCallback?.invoke(TtsPlaybackState.Playing)
 
@@ -336,7 +346,10 @@ class BailianTtsEngine(
         currentAudioTrack?.let { audioTrack ->
             try {
                 if (audioTrack.state == AudioTrack.STATE_INITIALIZED) {
-                    audioTrack.write(audioData, 0, audioData.size)
+                    val bytesWritten = audioTrack.write(audioData, 0, audioData.size)
+                    val writtenFrames =
+                        if (bytesWritten > 0) bytesWritten.toLong() / PCM_BYTES_PER_FRAME else 0L
+                    singleFramesWritten += writtenFrames
                 } else {
                     Log.w(TAG, "AudioTrack 状态异常")
                 }
@@ -399,6 +412,7 @@ class BailianTtsEngine(
                 .build()
 
             streamingAudioTrack?.play()
+            streamingFramesWritten = 0L
 
             val sessionId = newSessionId
             val request = Request.Builder()
@@ -547,24 +561,30 @@ class BailianTtsEngine(
             "task-started" -> {
                 if (streamingState == StreamingState.WAITING_TASK_STARTED) {
                     streamingState = StreamingState.READY
+                    onPlaybackStateCallback?.invoke(TtsPlaybackState.Playing)
                 }
             }
             "task-finished" -> {
                 streamingState = StreamingState.COMPLETED
+                onPlaybackStateCallback?.invoke(TtsPlaybackState.Completed)
             }
             "task-failed" -> {
                 streamingState = StreamingState.ERROR
+                onPlaybackStateCallback?.invoke(TtsPlaybackState.Error(response.header.error_message ?: "任务失败"))
             }
         }
     }
 
     private fun handleStreamingBinaryMessage(audioData: ByteArray) {
-        if (!isStreaming || streamingState != StreamingState.READY) return
+        if (!isStreaming || streamingState == StreamingState.IDLE || streamingState == StreamingState.ERROR) return
 
         streamingAudioTrack?.let { audioTrack ->
             try {
                 if (audioTrack.state == AudioTrack.STATE_INITIALIZED) {
-                    audioTrack.write(audioData, 0, audioData.size)
+                    val bytesWritten = audioTrack.write(audioData, 0, audioData.size)
+                    val writtenFrames =
+                        if (bytesWritten > 0) bytesWritten.toLong() / PCM_BYTES_PER_FRAME else 0L
+                    streamingFramesWritten += writtenFrames
                 } else {
                     Log.w(TAG, "AudioTrack 状态异常")
                 }
@@ -605,6 +625,7 @@ class BailianTtsEngine(
             }
             streamingAudioTrack = null
         }
+        streamingFramesWritten = 0L
 
         streamingWebSocket?.let { ws ->
             try {
@@ -639,6 +660,7 @@ class BailianTtsEngine(
             }
             currentAudioTrack = null
         }
+        singleFramesWritten = 0L
 
         currentWebSocket?.let { ws ->
             try {
@@ -648,6 +670,16 @@ class BailianTtsEngine(
             }
             currentWebSocket = null
         }
+    }
+
+    private fun hasPendingAudio(track: AudioTrack?, totalWrittenFrames: Long): Boolean {
+        val audioTrack = track ?: return false
+        if (totalWrittenFrames <= 0L) return false
+        if (audioTrack.state != AudioTrack.STATE_INITIALIZED) return false
+        if (audioTrack.playState != AudioTrack.PLAYSTATE_PLAYING) return false
+
+        val playedFrames = audioTrack.playbackHeadPosition.toLong() and 0xFFFFFFFFL
+        return totalWrittenFrames - playedFrames > 0L
     }
 }
 

--- a/app/src/main/java/com/alian/assistant/infrastructure/ai/tts/volcano/VolcanoTtsEngine.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/ai/tts/volcano/VolcanoTtsEngine.kt
@@ -11,6 +11,7 @@ import com.alian.assistant.infrastructure.ai.tts.TtsConfig
 import com.alian.assistant.infrastructure.ai.tts.TtsEngine
 import com.alian.assistant.infrastructure.ai.tts.TtsEngineFactory
 import com.alian.assistant.infrastructure.ai.tts.TtsPlaybackState
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -21,15 +22,20 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
+import org.json.JSONObject
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+import java.util.UUID
 import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
 
 /**
- * 火山引擎 TTS 引擎
- * 
- * 基于火山引擎 TTS API 实现
- * WebSocket 端点: wss://openspeech.bytedance.com/api/v1/tts_binary_llm
+ * 火山引擎 TTS（v3 双向流式）
+ *
+ * 文档：wss://openspeech.bytedance.com/api/v3/tts/bidirection
  */
 class VolcanoTtsEngine(
     private val config: TtsConfig
@@ -37,13 +43,53 @@ class VolcanoTtsEngine(
 
     companion object {
         private const val TAG = "VolcanoTtsEngine"
-        private const val WS_URL = "wss://openspeech.bytedance.com/api/v1/tts_binary_llm"
-        private const val SAMPLE_RATE = 16000
-        private const val CHANNEL_CONFIG = AudioFormat.CHANNEL_OUT_MONO
-        private const val AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT
+        private const val WS_URL = "wss://openspeech.bytedance.com/api/v3/tts/bidirection"
+
+        private const val DEFAULT_RESOURCE_ID = "seed-tts-2.0"
+        private const val DEFAULT_SPEAKER = "zh_female_shuangkuaisisi_uranus_bigtts"
+
+        private const val MESSAGE_TYPE_FULL_CLIENT_REQUEST = 0x1
+        private const val MESSAGE_TYPE_AUDIO_ONLY_REQUEST = 0x2
+        private const val MESSAGE_TYPE_FULL_SERVER_RESPONSE = 0x9
+        private const val MESSAGE_TYPE_AUDIO_ONLY_RESPONSE = 0xB
+        private const val MESSAGE_TYPE_ERROR = 0xF
+
+        private const val FLAG_WITH_EVENT = 0x4
+
+        private const val SERIALIZATION_RAW = 0x0
+        private const val SERIALIZATION_JSON = 0x1
+
+        private const val COMPRESSION_NONE = 0x0
+        private const val COMPRESSION_GZIP = 0x1
+
+        private const val EVENT_START_CONNECTION = 1
+        private const val EVENT_FINISH_CONNECTION = 2
+
+        private const val EVENT_CONNECTION_STARTED = 50
+        private const val EVENT_CONNECTION_FAILED = 51
+        private const val EVENT_CONNECTION_FINISHED = 52
+
+        private const val EVENT_START_SESSION = 100
+        private const val EVENT_CANCEL_SESSION = 101
+        private const val EVENT_FINISH_SESSION = 102
+
+        private const val EVENT_SESSION_STARTED = 150
+        private const val EVENT_SESSION_CANCELED = 151
+        private const val EVENT_SESSION_FINISHED = 152
+        private const val EVENT_SESSION_FAILED = 153
+
+        private const val EVENT_TASK_REQUEST = 200
+
+        private const val EVENT_TTS_SENTENCE_START = 350
+        private const val EVENT_TTS_SENTENCE_END = 351
+        private const val EVENT_TTS_RESPONSE = 352
+
+        private const val PCM_BYTES_PER_FRAME = 2L
     }
 
     override val provider: SpeechProvider = SpeechProvider.VOLCANO
+
+    private val sampleRate = if (config.sampleRate > 0) config.sampleRate else 16000
 
     private val client = OkHttpClient.Builder()
         .connectTimeout(30, TimeUnit.SECONDS)
@@ -52,27 +98,46 @@ class VolcanoTtsEngine(
         .pingInterval(0, TimeUnit.SECONDS)
         .build()
 
-    private var currentWebSocket: WebSocket? = null
-    private var currentAudioTrack: AudioTrack? = null
-    private var isPlaying = false
-
     private var onAudioDataCallback: ((ByteArray) -> Unit)? = null
     private var onPlaybackStateCallback: ((TtsPlaybackState) -> Unit)? = null
 
-    // 流式状态
+    private var currentWebSocket: WebSocket? = null
+    private var currentAudioTrack: AudioTrack? = null
+    private var isPlaying = false
+    @Volatile
+    private var singleFramesWritten: Long = 0L
+
     private var streamingWebSocket: WebSocket? = null
     private var streamingAudioTrack: AudioTrack? = null
-    private var isStreaming = false
-    private var streamingTaskId: String = ""
+    private var streamingState: StreamingState = StreamingState.IDLE
+    private var streamingSessionId: String = ""
+    @Volatile
+    private var streamingFramesWritten: Long = 0L
 
     private enum class StreamingState {
-        IDLE, WAITING_READY, READY, COMPLETED, ERROR
+        IDLE,
+        CONNECTING,
+        READY,
+        FINISHING,
+        COMPLETED,
+        ERROR
     }
 
-    private var streamingState = StreamingState.IDLE
-    private var currentSessionId: Long = 0
+    private data class ParsedFrame(
+        val messageType: Int,
+        val serialization: Int,
+        val compression: Int,
+        val event: Int?,
+        val id: String?,
+        val payload: ByteArray,
+        val errorCode: Int?
+    )
 
-    override fun isCurrentlyPlaying(): Boolean = isPlaying
+    override fun isCurrentlyPlaying(): Boolean {
+        val singlePlaying = hasPendingAudio(currentAudioTrack, singleFramesWritten)
+        val streamPlaying = hasPendingAudio(streamingAudioTrack, streamingFramesWritten)
+        return singlePlaying || streamPlaying
+    }
 
     override fun setOnAudioDataCallback(callback: ((ByteArray) -> Unit)?) {
         onAudioDataCallback = callback
@@ -83,439 +148,715 @@ class VolcanoTtsEngine(
     }
 
     override suspend fun synthesizeAndPlay(text: String, context: Context): Result<Unit> = withContext(Dispatchers.IO) {
-        try {
-            Log.d(TAG, "开始火山引擎语音合成: text长度=${text.length}")
+        if (text.isBlank()) return@withContext Result.success(Unit)
 
-            cancelPlayback()
+        cancelPlayback()
 
-            val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-            audioManager.requestAudioFocus(
-                null,
-                AudioManager.STREAM_MUSIC,
-                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
+        val completion = CompletableDeferred<Result<Unit>>()
+        val sessionId = UUID.randomUUID().toString().replace("-", "")
+        val audioTrack = createAudioTrack(context)
+        currentAudioTrack = audioTrack
+        singleFramesWritten = 0L
+
+        audioTrack.play()
+        isPlaying = true
+        onPlaybackStateCallback?.invoke(TtsPlaybackState.Playing)
+
+        val ws = createWebSocket(
+            onFrame = { frame ->
+                handleSingleFrame(
+                    ws = currentWebSocket,
+                    frame = frame,
+                    sessionId = sessionId,
+                    text = text,
+                    completion = completion
+                )
+            },
+            onFailure = { message ->
+                if (!completion.isCompleted) {
+                    completion.complete(Result.failure(IllegalStateException(message)))
+                }
+            },
+            onOpen = { socket ->
+                currentWebSocket = socket
+                sendStartConnection(socket)
+            },
+            onClosed = {
+                if (!completion.isCompleted && isPlaying) {
+                    completion.complete(Result.failure(IllegalStateException("连接提前关闭")))
+                }
+            }
+        )
+
+        currentWebSocket = ws
+        val result = withContext(Dispatchers.IO) {
+            completion.await()
+        }
+
+        // 给 AudioTrack 一点时间播放尾部缓冲
+        delay(80)
+        cleanupSingle()
+
+        if (result.isSuccess) {
+            onPlaybackStateCallback?.invoke(TtsPlaybackState.Completed)
+        } else {
+            onPlaybackStateCallback?.invoke(
+                TtsPlaybackState.Error(result.exceptionOrNull()?.message ?: "语音合成失败")
             )
-
-            val bufferSize = AudioTrack.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, AUDIO_FORMAT)
-            val actualBufferSize = bufferSize * 4
-
-            currentAudioTrack = AudioTrack.Builder()
-                .setAudioAttributes(
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_MEDIA)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                        .build()
-                )
-                .setAudioFormat(
-                    AudioFormat.Builder()
-                        .setEncoding(AUDIO_FORMAT)
-                        .setSampleRate(SAMPLE_RATE)
-                        .setChannelMask(CHANNEL_CONFIG)
-                        .build()
-                )
-                .setBufferSizeInBytes(actualBufferSize)
-                .setTransferMode(AudioTrack.MODE_STREAM)
-                .build()
-
-            currentAudioTrack?.play()
-            isPlaying = true
-            onPlaybackStateCallback?.invoke(TtsPlaybackState.Playing)
-
-            val authParams = buildAuthParams()
-            val request = Request.Builder()
-                .url("$WS_URL?$authParams")
-                .build()
-
-            val webSocketListener = object : WebSocketListener() {
-                override fun onOpen(ws: WebSocket, response: Response) {
-                    Log.d(TAG, "WebSocket 连接已建立")
-                    // 发送 TTS 请求
-                    sendTtsRequest(ws, text)
-                }
-
-                override fun onMessage(ws: WebSocket, text: String) {
-                    handleServerMessage(text)
-                }
-
-                override fun onMessage(ws: WebSocket, bytes: ByteString) {
-                    handleBinaryMessage(bytes.toByteArray())
-                }
-
-                override fun onClosing(ws: WebSocket, code: Int, reason: String) {
-                    Log.d(TAG, "WebSocket 正在关闭: code=$code, reason=$reason")
-                }
-
-                override fun onClosed(ws: WebSocket, code: Int, reason: String) {
-                    Log.d(TAG, "WebSocket 已关闭: code=$code, reason=$reason")
-                    cleanup()
-                }
-
-                override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
-                    Log.e(TAG, "WebSocket 连接失败", t)
-                    onPlaybackStateCallback?.invoke(TtsPlaybackState.Error(t.message ?: "连接失败"))
-                    cleanup()
-                }
-            }
-
-            currentWebSocket = client.newWebSocket(request, webSocketListener)
-
-            while (isPlaying) {
-                delay(100)
-            }
-
-            Log.d(TAG, "语音合成并播放完成")
-            Result.success(Unit)
-
-        } catch (e: Exception) {
-            Log.e(TAG, "语音合成失败", e)
-            onPlaybackStateCallback?.invoke(TtsPlaybackState.Error(e.message ?: "未知错误"))
-            cleanup()
-            Result.failure(e)
-        }
-    }
-
-    private fun buildAuthParams(): String {
-        val appId = config.appId
-        val token = config.apiKey
-        val cluster = config.cluster.ifEmpty { "volcano_tts" }
-        return "app_id=$appId&token=$token&cluster=$cluster"
-    }
-
-    private fun sendTtsRequest(ws: WebSocket, text: String) {
-        try {
-            // 构建火山引擎 TTS 请求
-            val requestJson = """
-                {
-                    "app": {
-                        "appid": "${config.appId}",
-                        "token": "${config.apiKey}",
-                        "cluster": "${config.cluster.ifEmpty { "volcano_tts" }}"
-                    },
-                    "user": {
-                        "uid": "user"
-                    },
-                    "audio": {
-                        "voice_type": "${config.voice}",
-                        "encoding": "pcm",
-                        "speed_ratio": ${config.speed},
-                        "volume_ratio": ${config.volume / 50.0},
-                        "pitch_ratio": 1.0
-                    },
-                    "request": {
-                        "reqid": "${System.currentTimeMillis()}",
-                        "text": "${text.replace("\"", "\\\"")}",
-                        "operation": "query"
-                    }
-                }
-            """.trimIndent()
-
-            ws.send(requestJson)
-            Log.d(TAG, "已发送 TTS 请求")
-        } catch (e: Exception) {
-            Log.e(TAG, "发送 TTS 请求失败", e)
-        }
-    }
-
-    private fun handleServerMessage(text: String) {
-        Log.d(TAG, "收到服务端消息: ${text.take(200)}")
-        try {
-            val response = org.json.JSONObject(text)
-            
-            val code = response.optInt("code", 0)
-            if (code != 0) {
-                val message = response.optString("message", "未知错误")
-                Log.e(TAG, "TTS 错误: $message (code: $code)")
-                isPlaying = false
-                onPlaybackStateCallback?.invoke(TtsPlaybackState.Error(message))
-                return
-            }
-
-            // 检查是否完成
-            val isComplete = response.optBoolean("is_complete", false)
-            if (isComplete) {
-                isPlaying = false
-                onPlaybackStateCallback?.invoke(TtsPlaybackState.Completed)
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "解析服务端消息失败", e)
-        }
-    }
-
-    private fun handleBinaryMessage(audioData: ByteArray) {
-        currentAudioTrack?.let { audioTrack ->
-            try {
-                if (audioTrack.state == AudioTrack.STATE_INITIALIZED) {
-                    // 火山引擎二进制响应可能包含头部，需要解析
-                    val pcmData = parseBinaryAudio(audioData)
-                    if (pcmData != null) {
-                        audioTrack.write(pcmData, 0, pcmData.size)
-                    } else {
-                        Log.w(TAG, "无法解析音频数据")
-                    }
-                } else {
-                    Log.w(TAG, "AudioTrack 状态异常")
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "AudioTrack 写入失败", e)
-            }
-        }
-        onAudioDataCallback?.invoke(audioData)
-    }
-
-    /**
-     * 解析火山引擎二进制音频数据
-     * 火山引擎返回的二进制数据可能包含协议头
-     */
-    private fun parseBinaryAudio(data: ByteArray): ByteArray? {
-        if (data.size < 11) return null
-
-        // 解析头部
-        val buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN)
-        val protocolVersion = buffer.get().toInt() and 0xFF
-        val headerSize = buffer.short.toInt() and 0xFFFF
-        val payloadType = buffer.get().toInt() and 0xFF
-        val payloadSize = buffer.int
-
-        // 检查是否为音频数据
-        if (payloadType != 1 && payloadType != 3) return null
-
-        // 提取 PCM 数据
-        if (data.size >= headerSize + payloadSize) {
-            return data.copyOfRange(headerSize, headerSize + payloadSize)
         }
 
-        return null
+        result
     }
 
     override suspend fun startStreamingSession(context: Context): Result<Unit> = withContext(Dispatchers.IO) {
-        try {
-            val newSessionId = System.currentTimeMillis()
-            currentSessionId = newSessionId
-            streamingTaskId = newSessionId.toString()
+        stopStreamingSessionInternal()
 
-            isStreaming = true
-            streamingState = StreamingState.WAITING_READY
+        val readyDeferred = CompletableDeferred<Result<Unit>>()
+        streamingSessionId = UUID.randomUUID().toString().replace("-", "")
+        streamingState = StreamingState.CONNECTING
 
-            val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-            audioManager.requestAudioFocus(
-                null,
-                AudioManager.STREAM_MUSIC,
-                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
-            )
+        val track = createAudioTrack(context)
+        streamingAudioTrack = track
+        streamingFramesWritten = 0L
+        track.play()
 
-            val bufferSize = AudioTrack.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, AUDIO_FORMAT)
-            val actualBufferSize = bufferSize * 4
-
-            streamingAudioTrack = AudioTrack.Builder()
-                .setAudioAttributes(
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_MEDIA)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                        .build()
+        val ws = createWebSocket(
+            onFrame = { frame ->
+                handleStreamingFrame(
+                    ws = streamingWebSocket,
+                    frame = frame,
+                    readyDeferred = readyDeferred
                 )
-                .setAudioFormat(
-                    AudioFormat.Builder()
-                        .setEncoding(AUDIO_FORMAT)
-                        .setSampleRate(SAMPLE_RATE)
-                        .setChannelMask(CHANNEL_CONFIG)
-                        .build()
-                )
-                .setBufferSizeInBytes(actualBufferSize)
-                .setTransferMode(AudioTrack.MODE_STREAM)
-                .build()
-
-            streamingAudioTrack?.play()
-
-            val authParams = buildAuthParams()
-            val sessionId = newSessionId
-            val request = Request.Builder()
-                .url("$WS_URL?$authParams")
-                .build()
-
-            val webSocketListener = object : WebSocketListener() {
-                override fun onOpen(ws: WebSocket, response: Response) {
-                    if (sessionId != currentSessionId) {
-                        ws.close(1000, "会话已过期")
-                        return
-                    }
-                    streamingState = StreamingState.READY
+            },
+            onFailure = { message ->
+                streamingState = StreamingState.ERROR
+                if (!readyDeferred.isCompleted) {
+                    readyDeferred.complete(Result.failure(IllegalStateException(message)))
                 }
-
-                override fun onMessage(ws: WebSocket, text: String) {
-                    if (sessionId != currentSessionId) return
-                    handleStreamingTextMessage(text)
-                }
-
-                override fun onMessage(ws: WebSocket, bytes: ByteString) {
-                    if (sessionId != currentSessionId) return
-                    handleStreamingBinaryMessage(bytes.toByteArray())
-                }
-
-                override fun onClosed(ws: WebSocket, code: Int, reason: String) {
-                    if (sessionId == currentSessionId) {
-                        streamingState = StreamingState.COMPLETED
-                    }
-                }
-
-                override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
-                    if (sessionId == currentSessionId) {
-                        streamingState = StreamingState.ERROR
-                    }
+            },
+            onOpen = { socket ->
+                streamingWebSocket = socket
+                sendStartConnection(socket)
+            },
+            onClosed = {
+                if (!readyDeferred.isCompleted && streamingState != StreamingState.READY) {
+                    readyDeferred.complete(Result.failure(IllegalStateException("流式连接提前关闭")))
                 }
             }
+        )
 
-            streamingWebSocket = client.newWebSocket(request, webSocketListener)
+        streamingWebSocket = ws
 
-            var attempts = 0
-            while (streamingState == StreamingState.WAITING_READY && attempts < 300) {
-                delay(100)
-                attempts++
-            }
-
-            if (streamingState != StreamingState.READY) {
-                stopStreamingSession()
-                return@withContext Result.failure(Exception("流式会话启动失败"))
-            }
-
-            Result.success(Unit)
-
-        } catch (e: Exception) {
-            stopStreamingSession()
-            Result.failure(e)
+        val result = readyDeferred.await()
+        if (result.isFailure) {
+            stopStreamingSessionInternal()
         }
+        result
     }
 
     override fun sendStreamingChunk(chunk: String): Result<Unit> {
-        if (!isStreaming || streamingState != StreamingState.READY) {
-            return Result.failure(Exception("流式会话未就绪"))
+        if (chunk.isBlank()) return Result.success(Unit)
+        if (streamingState != StreamingState.READY) {
+            return Result.failure(IllegalStateException("流式会话未就绪"))
         }
 
-        if (chunk.isBlank()) {
-            return Result.success(Unit)
-        }
-
+        val ws = streamingWebSocket ?: return Result.failure(IllegalStateException("流式连接不存在"))
         return try {
-            sendTtsRequest(streamingWebSocket!!, chunk)
+            sendTaskRequest(ws, streamingSessionId, chunk)
             Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
+        } catch (t: Throwable) {
+            Result.failure(t)
         }
     }
 
     override fun finishStreamingSession(): Result<Unit> {
-        if (!isStreaming || streamingState != StreamingState.READY) {
-            return Result.failure(Exception("流式会话未就绪"))
+        if (streamingState != StreamingState.READY && streamingState != StreamingState.FINISHING) {
+            return Result.failure(IllegalStateException("流式会话未就绪"))
         }
 
+        val ws = streamingWebSocket ?: return Result.failure(IllegalStateException("流式连接不存在"))
         return try {
-            streamingWebSocket?.close(1000, "正常关闭")
-            streamingState = StreamingState.COMPLETED
+            sendFinishSession(ws, streamingSessionId)
+            streamingState = StreamingState.FINISHING
             Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
+        } catch (t: Throwable) {
+            Result.failure(t)
         }
-    }
-
-    private fun handleStreamingTextMessage(text: String) {
-        try {
-            val response = org.json.JSONObject(text)
-            val code = response.optInt("code", 0)
-            if (code != 0) {
-                streamingState = StreamingState.ERROR
-            }
-            val isComplete = response.optBoolean("is_complete", false)
-            if (isComplete) {
-                streamingState = StreamingState.COMPLETED
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "解析流式文本消息失败", e)
-        }
-    }
-
-    private fun handleStreamingBinaryMessage(audioData: ByteArray) {
-        if (!isStreaming || streamingState != StreamingState.READY) return
-
-        streamingAudioTrack?.let { audioTrack ->
-            try {
-                if (audioTrack.state == AudioTrack.STATE_INITIALIZED) {
-                    val pcmData = parseBinaryAudio(audioData)
-                    if (pcmData != null) {
-                        audioTrack.write(pcmData, 0, pcmData.size)
-                    } else {
-                        Log.w(TAG, "无法解析音频数据")
-                    }
-                } else {
-                    Log.w(TAG, "AudioTrack 状态异常")
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "写入流式音频数据失败", e)
-            }
-        }
-        onAudioDataCallback?.invoke(audioData)
     }
 
     override fun cancelPlayback() {
-        if (isPlaying) {
-            isPlaying = false
-            cleanup()
-        }
-        if (isStreaming) {
-            stopStreamingSession()
-        }
-    }
-
-    private fun stopStreamingSession() {
-        currentSessionId = 0
-        isStreaming = false
-        streamingState = StreamingState.IDLE
-
-        streamingAudioTrack?.let { audioTrack ->
-            try {
-                if (audioTrack.state == AudioTrack.STATE_INITIALIZED) {
-                    audioTrack.stop()
-                }
-                audioTrack.release()
-            } catch (e: Exception) {
-                Log.e(TAG, "释放流式 AudioTrack 失败", e)
-            }
-            streamingAudioTrack = null
-        }
-
-        streamingWebSocket?.let { ws ->
-            try {
-                ws.close(1000, "正常关闭")
-            } catch (e: Exception) {
-                Log.e(TAG, "关闭流式 WebSocket 失败", e)
-            }
-            streamingWebSocket = null
-        }
+        cleanupSingle()
+        stopStreamingSessionInternal()
     }
 
     override fun release() {
         cancelPlayback()
     }
 
-    private fun cleanup() {
-        isPlaying = false
-
-        currentAudioTrack?.let { audioTrack ->
-            try {
-                if (audioTrack.state == AudioTrack.STATE_INITIALIZED) {
-                    audioTrack.stop()
-                }
-                audioTrack.release()
-            } catch (e: Exception) {
-                Log.e(TAG, "释放 AudioTrack 失败", e)
-            }
-            currentAudioTrack = null
+    private fun handleSingleFrame(
+        ws: WebSocket?,
+        frame: ParsedFrame,
+        sessionId: String,
+        text: String,
+        completion: CompletableDeferred<Result<Unit>>
+    ) {
+        if (frame.messageType == MESSAGE_TYPE_ERROR) {
+            val msg = decodePayloadAsText(frame.payload)
+            val message = "TTS 协议错误(${frame.errorCode ?: -1}): $msg"
+            Log.e(TAG, message)
+            if (!completion.isCompleted) completion.complete(Result.failure(IllegalStateException(message)))
+            return
         }
 
-        currentWebSocket?.let { ws ->
-            try {
-                ws.close(1000, "正常关闭")
-            } catch (e: Exception) {
-                Log.e(TAG, "关闭 WebSocket 失败", e)
+        when (frame.messageType) {
+            MESSAGE_TYPE_AUDIO_ONLY_RESPONSE -> {
+                if (frame.event == EVENT_TTS_RESPONSE || frame.event == null) {
+                    writeAudio(currentAudioTrack, frame.payload, isStreamingAudio = false)
+                }
             }
-            currentWebSocket = null
+
+            MESSAGE_TYPE_FULL_SERVER_RESPONSE -> {
+                when (frame.event) {
+                    EVENT_CONNECTION_STARTED -> {
+                        ws?.let { sendStartSession(it, sessionId) }
+                    }
+
+                    EVENT_CONNECTION_FAILED -> {
+                        val message = parseStatusMessage(frame.payload, "建连失败")
+                        if (!completion.isCompleted) completion.complete(Result.failure(IllegalStateException(message)))
+                    }
+
+                    EVENT_SESSION_STARTED -> {
+                        ws?.let {
+                            sendTaskRequest(it, sessionId, text)
+                            sendFinishSession(it, sessionId)
+                        }
+                    }
+
+                    EVENT_TTS_RESPONSE -> {
+                        if (frame.serialization == SERIALIZATION_RAW) {
+                            writeAudio(currentAudioTrack, frame.payload, isStreamingAudio = false)
+                        }
+                    }
+
+                    EVENT_SESSION_FINISHED -> {
+                        val status = parseStatusCode(frame.payload)
+                        if (status == 20000000 || status == 0) {
+                            if (!completion.isCompleted) completion.complete(Result.success(Unit))
+                        } else {
+                            val message = parseStatusMessage(frame.payload, "会话结束异常")
+                            if (!completion.isCompleted) completion.complete(Result.failure(IllegalStateException(message)))
+                        }
+                        ws?.let { sendFinishConnection(it) }
+                    }
+
+                    EVENT_SESSION_FAILED,
+                    EVENT_SESSION_CANCELED -> {
+                        val message = parseStatusMessage(frame.payload, "会话失败")
+                        if (!completion.isCompleted) completion.complete(Result.failure(IllegalStateException(message)))
+                        ws?.let { sendFinishConnection(it) }
+                    }
+
+                    EVENT_CONNECTION_FINISHED -> {
+                        // 正常结束连接，无需额外处理
+                    }
+                }
+            }
+        }
+    }
+
+    private fun handleStreamingFrame(
+        ws: WebSocket?,
+        frame: ParsedFrame,
+        readyDeferred: CompletableDeferred<Result<Unit>>
+    ) {
+        if (frame.messageType == MESSAGE_TYPE_ERROR) {
+            val msg = decodePayloadAsText(frame.payload)
+            val message = "TTS 协议错误(${frame.errorCode ?: -1}): $msg"
+            Log.e(TAG, message)
+            streamingState = StreamingState.ERROR
+            if (!readyDeferred.isCompleted) {
+                readyDeferred.complete(Result.failure(IllegalStateException(message)))
+            }
+            onPlaybackStateCallback?.invoke(TtsPlaybackState.Error(message))
+            return
+        }
+
+        when (frame.messageType) {
+            MESSAGE_TYPE_AUDIO_ONLY_RESPONSE -> {
+                if (frame.event == EVENT_TTS_RESPONSE || frame.event == null) {
+                    writeAudio(streamingAudioTrack, frame.payload, isStreamingAudio = true)
+                }
+            }
+
+            MESSAGE_TYPE_FULL_SERVER_RESPONSE -> {
+                when (frame.event) {
+                    EVENT_CONNECTION_STARTED -> {
+                        ws?.let { sendStartSession(it, streamingSessionId) }
+                    }
+
+                    EVENT_CONNECTION_FAILED -> {
+                        val message = parseStatusMessage(frame.payload, "流式建连失败")
+                        streamingState = StreamingState.ERROR
+                        if (!readyDeferred.isCompleted) {
+                            readyDeferred.complete(Result.failure(IllegalStateException(message)))
+                        }
+                        onPlaybackStateCallback?.invoke(TtsPlaybackState.Error(message))
+                    }
+
+                    EVENT_SESSION_STARTED -> {
+                        streamingState = StreamingState.READY
+                        if (!readyDeferred.isCompleted) {
+                            readyDeferred.complete(Result.success(Unit))
+                        }
+                    }
+
+                    EVENT_TTS_RESPONSE -> {
+                        if (frame.serialization == SERIALIZATION_RAW) {
+                            writeAudio(streamingAudioTrack, frame.payload, isStreamingAudio = true)
+                        }
+                    }
+
+                    EVENT_SESSION_FINISHED -> {
+                        streamingState = StreamingState.COMPLETED
+                        onPlaybackStateCallback?.invoke(TtsPlaybackState.Completed)
+                        ws?.let { sendFinishConnection(it) }
+                    }
+
+                    EVENT_SESSION_FAILED,
+                    EVENT_SESSION_CANCELED -> {
+                        val message = parseStatusMessage(frame.payload, "流式会话失败")
+                        streamingState = StreamingState.ERROR
+                        if (!readyDeferred.isCompleted) {
+                            readyDeferred.complete(Result.failure(IllegalStateException(message)))
+                        }
+                        onPlaybackStateCallback?.invoke(TtsPlaybackState.Error(message))
+                        ws?.let { sendFinishConnection(it) }
+                    }
+
+                    EVENT_CONNECTION_FINISHED -> {
+                        // 连接已结束
+                    }
+                }
+            }
+        }
+    }
+
+    private fun createWebSocket(
+        onFrame: (ParsedFrame) -> Unit,
+        onFailure: (String) -> Unit,
+        onOpen: (WebSocket) -> Unit,
+        onClosed: () -> Unit
+    ): WebSocket {
+        val resourceId = config.resourceId.ifBlank {
+            if (config.model.startsWith("seed-tts-", ignoreCase = true)) {
+                config.model
+            } else {
+                DEFAULT_RESOURCE_ID
+            }
+        }
+        val request = Request.Builder()
+            .url(WS_URL)
+            .addHeader("X-Api-App-Key", config.appId)
+            .addHeader("X-Api-Access-Key", config.apiKey)
+            .addHeader("X-Api-Resource-Id", resourceId)
+            .addHeader("X-Api-Connect-Id", UUID.randomUUID().toString())
+            .build()
+
+        val listener = object : WebSocketListener() {
+            override fun onOpen(ws: WebSocket, response: Response) {
+                onOpen(ws)
+            }
+
+            override fun onMessage(ws: WebSocket, bytes: ByteString) {
+                try {
+                    val parsed = parseBinaryFrame(bytes.toByteArray())
+                    onFrame(parsed)
+                } catch (t: Throwable) {
+                    Log.e(TAG, "parse frame failed", t)
+                    onFailure("解析服务端消息失败: ${t.message}")
+                }
+            }
+
+            override fun onMessage(ws: WebSocket, text: String) {
+                onFailure("服务端文本错误: ${text.take(300)}")
+            }
+
+            override fun onClosed(ws: WebSocket, code: Int, reason: String) {
+                onClosed()
+            }
+
+            override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
+                onFailure("连接失败: ${t.message}")
+            }
+        }
+
+        return client.newWebSocket(request, listener)
+    }
+
+    private fun sendStartConnection(ws: WebSocket) {
+        ws.send(buildFullRequestFrame(EVENT_START_CONNECTION, null, JSONObject().toString()).toByteString())
+    }
+
+    private fun sendFinishConnection(ws: WebSocket) {
+        ws.send(buildFullRequestFrame(EVENT_FINISH_CONNECTION, null, JSONObject().toString()).toByteString())
+    }
+
+    private fun sendStartSession(ws: WebSocket, sessionId: String) {
+        val speaker = normalizeSpeaker(config.voice)
+        val reqParams = JSONObject().apply {
+            put("speaker", speaker)
+            put("audio_params", JSONObject().apply {
+                put("format", "pcm")
+                put("sample_rate", sampleRate)
+                put("speech_rate", mapSpeechRate(config.speed))
+                put("loudness_rate", mapLoudnessRate(config.volume))
+            })
+        }
+
+        val payload = JSONObject().apply {
+            put("user", JSONObject().apply {
+                put("uid", "beanbun-android")
+            })
+            put("req_params", reqParams)
+        }
+
+        ws.send(buildFullRequestFrame(EVENT_START_SESSION, sessionId, payload.toString()).toByteString())
+    }
+
+    private fun sendFinishSession(ws: WebSocket, sessionId: String) {
+        ws.send(buildFullRequestFrame(EVENT_FINISH_SESSION, sessionId, JSONObject().toString()).toByteString())
+    }
+
+    private fun sendCancelSession(ws: WebSocket, sessionId: String) {
+        ws.send(buildFullRequestFrame(EVENT_CANCEL_SESSION, sessionId, JSONObject().toString()).toByteString())
+    }
+
+    private fun sendTaskRequest(ws: WebSocket, sessionId: String, text: String) {
+        val payload = JSONObject().apply {
+            put("req_params", JSONObject().apply {
+                put("text", text)
+            })
+        }
+        ws.send(buildFullRequestFrame(EVENT_TASK_REQUEST, sessionId, payload.toString()).toByteString())
+    }
+
+    private fun buildFullRequestFrame(event: Int, sessionId: String?, payloadJson: String): ByteArray {
+        val payload = payloadJson.toByteArray(StandardCharsets.UTF_8)
+        val sessionBytes = sessionId?.toByteArray(StandardCharsets.UTF_8)
+
+        val header = byteArrayOf(
+            ((1 shl 4) or 1).toByte(),
+            ((MESSAGE_TYPE_FULL_CLIENT_REQUEST shl 4) or FLAG_WITH_EVENT).toByte(),
+            ((SERIALIZATION_JSON shl 4) or COMPRESSION_NONE).toByte(),
+            0x00
+        )
+
+        val total = header.size + 4 + (if (sessionBytes != null) 4 + sessionBytes.size else 0) + 4 + payload.size
+        return ByteBuffer.allocate(total)
+            .order(ByteOrder.BIG_ENDIAN)
+            .put(header)
+            .putInt(event)
+            .apply {
+                if (sessionBytes != null) {
+                    putInt(sessionBytes.size)
+                    put(sessionBytes)
+                }
+            }
+            .putInt(payload.size)
+            .put(payload)
+            .array()
+    }
+
+    private fun parseBinaryFrame(frame: ByteArray): ParsedFrame {
+        require(frame.size >= 8) { "frame too short" }
+
+        val header0 = frame[0].toInt() and 0xFF
+        val version = (header0 ushr 4) and 0x0F
+        val headerSize = (header0 and 0x0F) * 4
+        require(version == 1) { "unsupported protocol version=$version" }
+
+        val b1 = frame[1].toInt() and 0xFF
+        val messageType = (b1 ushr 4) and 0x0F
+        val flags = b1 and 0x0F
+
+        val b2 = frame[2].toInt() and 0xFF
+        val serialization = (b2 ushr 4) and 0x0F
+        val compression = b2 and 0x0F
+
+        var offset = headerSize
+
+        if (messageType == MESSAGE_TYPE_ERROR) {
+            val errorCode = readInt32BE(frame, offset)
+            offset += 4
+            val payloadSize = readInt32BE(frame, offset)
+            offset += 4
+            require(payloadSize >= 0 && frame.size >= offset + payloadSize) { "invalid error payload size" }
+            val payload = frame.copyOfRange(offset, offset + payloadSize)
+            return ParsedFrame(
+                messageType = messageType,
+                serialization = serialization,
+                compression = compression,
+                event = null,
+                id = null,
+                payload = payload,
+                errorCode = errorCode
+            )
+        }
+
+        var event: Int? = null
+        if (flags == FLAG_WITH_EVENT) {
+            event = readInt32BE(frame, offset)
+            offset += 4
+        }
+
+        var id: String? = null
+        if (event != null && shouldFrameContainId(event)) {
+            val idLen = readInt32BE(frame, offset)
+            offset += 4
+            if (idLen > 0) {
+                require(frame.size >= offset + idLen) { "invalid id length=$idLen" }
+                id = frame.copyOfRange(offset, offset + idLen).toString(StandardCharsets.UTF_8)
+                offset += idLen
+            }
+        }
+
+        val payloadSize = readInt32BE(frame, offset)
+        offset += 4
+        require(payloadSize >= 0 && frame.size >= offset + payloadSize) { "invalid payload size=$payloadSize" }
+
+        val rawPayload = frame.copyOfRange(offset, offset + payloadSize)
+        val payload = when (compression) {
+            COMPRESSION_GZIP -> ungzip(rawPayload)
+            else -> rawPayload
+        }
+
+        return ParsedFrame(
+            messageType = messageType,
+            serialization = serialization,
+            compression = compression,
+            event = event,
+            id = id,
+            payload = payload,
+            errorCode = null
+        )
+    }
+
+    private fun shouldFrameContainId(event: Int): Boolean {
+        return when (event) {
+            EVENT_CONNECTION_STARTED,
+            EVENT_CONNECTION_FAILED,
+            EVENT_CONNECTION_FINISHED,
+            EVENT_START_SESSION,
+            EVENT_CANCEL_SESSION,
+            EVENT_FINISH_SESSION,
+            EVENT_SESSION_STARTED,
+            EVENT_SESSION_CANCELED,
+            EVENT_SESSION_FINISHED,
+            EVENT_SESSION_FAILED,
+            EVENT_TASK_REQUEST,
+            EVENT_TTS_SENTENCE_START,
+            EVENT_TTS_SENTENCE_END,
+            EVENT_TTS_RESPONSE -> true
+
+            else -> false
+        }
+    }
+
+    private fun writeAudio(audioTrack: AudioTrack?, audioData: ByteArray, isStreamingAudio: Boolean) {
+        if (audioData.isEmpty()) return
+        val track = audioTrack ?: return
+        if (track.state != AudioTrack.STATE_INITIALIZED) return
+
+        try {
+            val bytesWritten = track.write(audioData, 0, audioData.size)
+            if (bytesWritten > 0) {
+                if (isStreamingAudio) {
+                    streamingFramesWritten += bytesWritten.toLong() / PCM_BYTES_PER_FRAME
+                } else {
+                    singleFramesWritten += bytesWritten.toLong() / PCM_BYTES_PER_FRAME
+                }
+            }
+            onAudioDataCallback?.invoke(audioData)
+        } catch (t: Throwable) {
+            Log.e(TAG, "write audio failed", t)
+        }
+    }
+
+    private fun cleanupSingle() {
+        isPlaying = false
+
+        try {
+            currentWebSocket?.close(1000, "normal")
+        } catch (t: Throwable) {
+            Log.w(TAG, "close single websocket failed", t)
+        }
+        currentWebSocket = null
+
+        try {
+            currentAudioTrack?.let {
+                if (it.state == AudioTrack.STATE_INITIALIZED) {
+                    if (it.playState == AudioTrack.PLAYSTATE_PLAYING) {
+                        it.stop()
+                    }
+                    it.release()
+                }
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "release single audio track failed", t)
+        }
+        currentAudioTrack = null
+        singleFramesWritten = 0L
+    }
+
+    private fun stopStreamingSessionInternal() {
+        if (streamingState == StreamingState.IDLE) return
+
+        try {
+            val ws = streamingWebSocket
+            if (ws != null && streamingSessionId.isNotBlank() &&
+                (streamingState == StreamingState.READY || streamingState == StreamingState.FINISHING)
+            ) {
+                sendCancelSession(ws, streamingSessionId)
+            }
+            ws?.let { sendFinishConnection(it) }
+            ws?.close(1000, "normal")
+        } catch (t: Throwable) {
+            Log.w(TAG, "stop streaming websocket failed", t)
+        }
+        streamingWebSocket = null
+
+        try {
+            streamingAudioTrack?.let {
+                if (it.state == AudioTrack.STATE_INITIALIZED) {
+                    if (it.playState == AudioTrack.PLAYSTATE_PLAYING) {
+                        it.stop()
+                    }
+                    it.release()
+                }
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "release streaming audio track failed", t)
+        }
+        streamingAudioTrack = null
+        streamingFramesWritten = 0L
+
+        streamingSessionId = ""
+        streamingState = StreamingState.IDLE
+    }
+
+    private fun hasPendingAudio(track: AudioTrack?, totalWrittenFrames: Long): Boolean {
+        val audioTrack = track ?: return false
+        if (totalWrittenFrames <= 0L) return false
+        if (audioTrack.state != AudioTrack.STATE_INITIALIZED) return false
+        if (audioTrack.playState != AudioTrack.PLAYSTATE_PLAYING) return false
+
+        val playedFrames = audioTrack.playbackHeadPosition.toLong() and 0xFFFFFFFFL
+        return totalWrittenFrames - playedFrames > 0L
+    }
+
+    private fun createAudioTrack(context: Context): AudioTrack {
+        val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        audioManager.requestAudioFocus(
+            null,
+            AudioManager.STREAM_MUSIC,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
+        )
+
+        val channelConfig = AudioFormat.CHANNEL_OUT_MONO
+        val audioFormat = AudioFormat.ENCODING_PCM_16BIT
+        val minBuffer = AudioTrack.getMinBufferSize(sampleRate, channelConfig, audioFormat)
+
+        return AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(audioFormat)
+                    .setSampleRate(sampleRate)
+                    .setChannelMask(channelConfig)
+                    .build()
+            )
+            .setBufferSizeInBytes((minBuffer * 4).coerceAtLeast(minBuffer))
+            .setTransferMode(AudioTrack.MODE_STREAM)
+            .build()
+    }
+
+    private fun readInt32BE(bytes: ByteArray, offset: Int): Int {
+        return ByteBuffer.wrap(bytes, offset, 4).order(ByteOrder.BIG_ENDIAN).int
+    }
+
+    private fun decodePayloadAsText(payload: ByteArray): String {
+        if (payload.isEmpty()) return ""
+        return try {
+            payload.toString(StandardCharsets.UTF_8)
+        } catch (_: Throwable) {
+            ""
+        }
+    }
+
+    private fun parseStatusCode(payload: ByteArray): Int {
+        return try {
+            val json = JSONObject(decodePayloadAsText(payload))
+            when {
+                json.has("status_code") -> json.optInt("status_code")
+                json.has("code") -> json.optInt("code")
+                else -> 20000000
+            }
+        } catch (_: Throwable) {
+            20000000
+        }
+    }
+
+    private fun parseStatusMessage(payload: ByteArray, defaultMessage: String): String {
+        return try {
+            val json = JSONObject(decodePayloadAsText(payload))
+            val code = when {
+                json.has("status_code") -> json.optInt("status_code")
+                json.has("code") -> json.optInt("code")
+                else -> 0
+            }
+            val msg = json.optString("message", defaultMessage)
+            if (code != 0) "$msg($code)" else msg
+        } catch (_: Throwable) {
+            defaultMessage
+        }
+    }
+
+    private fun normalizeSpeaker(input: String): String {
+        if (input.isBlank()) return DEFAULT_SPEAKER
+        if (input.startsWith("zh_") || input.startsWith("en_") || input.startsWith("S_") || input.startsWith("icl_") || input.startsWith("saturn_")) {
+            return input
+        }
+        return DEFAULT_SPEAKER
+    }
+
+    private fun mapSpeechRate(speed: Float): Int {
+        val normalized = ((speed - 1.0f) * 100f).toInt()
+        return normalized.coerceIn(-50, 100)
+    }
+
+    private fun mapLoudnessRate(volume: Int): Int {
+        val normalized = (volume.coerceIn(0, 100) - 50) * 2
+        return normalized.coerceIn(-50, 100)
+    }
+
+    private fun ungzip(data: ByteArray): ByteArray {
+        ByteArrayInputStream(data).use { bis ->
+            GZIPInputStream(bis).use { gis ->
+                val out = ByteArrayOutputStream()
+                val buffer = ByteArray(4096)
+                while (true) {
+                    val read = gis.read(buffer)
+                    if (read <= 0) break
+                    out.write(buffer, 0, read)
+                }
+                return out.toByteArray()
+            }
         }
     }
 }

--- a/app/src/main/java/com/alian/assistant/infrastructure/audio/AecVoiceCallAudioManager.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/audio/AecVoiceCallAudioManager.kt
@@ -6,11 +6,18 @@ import android.content.pm.PackageManager
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.util.Log
-import com.alibaba.fastjson.JSON
 import com.alian.assistant.common.utils.SpeechTextGuard
 import com.alian.assistant.common.utils.VoiceTerminalMetrics
 import com.alian.assistant.data.SettingsManager
+import com.alian.assistant.data.model.SpeechProvider
+import com.alian.assistant.data.model.SpeechProviderConfig
+import com.alian.assistant.infrastructure.ai.asr.AsrConfig
+import com.alian.assistant.infrastructure.ai.asr.AsrEngine
+import com.alian.assistant.infrastructure.ai.asr.AsrListener
+import com.alian.assistant.infrastructure.ai.asr.ExternalPcmConsumer
 import com.alian.assistant.infrastructure.ai.asr.SherpaOfflineSpeechRecognizer
+import com.alian.assistant.infrastructure.ai.asr.bailian.BailianAsrEngine
+import com.alian.assistant.infrastructure.ai.asr.volcano.VolcanoAsrEngine
 import com.alian.assistant.infrastructure.ai.tts.HybridTtsClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +32,7 @@ import kotlinx.coroutines.launch
  * 
  * 功能：
  * 1. 使用 AecAudioProcessor 进行回声消除
- * 2. 使用 AecQwenSpeechClient 进行语音识别
+ * 2. 使用统一 ASR 引擎（百炼/火山）进行语音识别
  * 3. 实现真正的语音打断功能
  */
 class AecVoiceCallAudioManager(
@@ -45,6 +52,10 @@ class AecVoiceCallAudioManager(
     companion object {
         private const val TAG = "AecVoiceCallAudioManager"
         private const val SILENCE_DURATION_MS = Long.MAX_VALUE  // 静音持续时间
+        private const val CLOUD_UTTERANCE_SILENCE_MS = 1500L    // 云识别单句静音收尾阈值
+        private const val STREAM_SETTLE_TIMEOUT_MS = 5000L      // 流式会话收敛超时
+        private const val STREAM_AUDIO_DRAIN_TIMEOUT_MS = 3000L // AudioTrack 缓冲排空超时
+        private const val STREAM_ONLY_GRACE_MS = 1500L          // 仅剩流式状态的容忍时间
     }
 
     // 音频管理器
@@ -53,8 +64,9 @@ class AecVoiceCallAudioManager(
     // AEC 音频处理器
     private var aecAudioProcessor: AecAudioProcessor? = null
 
-    // 语音识别客户端（支持 AEC）
-    private var aecQwenSpeechClient: AecQwenSpeechClient? = null
+    // 在线语音识别引擎（支持 AEC 外部 PCM 推流）
+    private var cloudAsrEngine: AsrEngine? = null
+    private var cloudPcmConsumer: ExternalPcmConsumer? = null
 
     // 离线语音识别客户端
     private var offlineAsrRecognizer: SherpaOfflineSpeechRecognizer? = null
@@ -82,6 +94,8 @@ class AecVoiceCallAudioManager(
 
     // 最后一次检测到音频的时间
     private var lastAudioTime: Long = 0
+    // 当前轮次是否已检测到有效说话内容（用于云识别单句自动收尾）
+    private var hasSpeechInCurrentTurn: Boolean = false
 
     // 播放中断回调（语音打断时调用）
     private var onPlaybackInterrupted: (() -> Unit)? = null
@@ -148,16 +162,6 @@ class AecVoiceCallAudioManager(
      * 初始化客户端
      */
     private fun initializeClients() {
-        // 初始化语音识别客户端（支持 AEC）
-        aecQwenSpeechClient = AecQwenSpeechClient(
-            apiKey = apiKey,
-            url = "wss://dashscope.aliyuncs.com/api-ws/v1/inference",
-            model = "fun-asr-realtime-2025-09-15",
-            sampleRate = 16000,
-            audioFormat = "pcm",
-            vadEnabled = true
-        )
-
         // 初始化 AEC 音频处理器
         aecAudioProcessor = AecAudioProcessor(
             sampleRate = 16000,
@@ -169,7 +173,11 @@ class AecVoiceCallAudioManager(
         // 设置 AEC 处理后的音频回调
         aecAudioProcessor?.setOnProcessedAudio { processedAudio ->
             when (activeAsrEngine) {
-                ActiveAsrEngine.CLOUD -> aecQwenSpeechClient?.addAudioData(processedAudio)
+                ActiveAsrEngine.CLOUD -> cloudPcmConsumer?.appendPcm(
+                    processedAudio,
+                    sampleRate = 16000,
+                    channels = 1
+                )
                 ActiveAsrEngine.OFFLINE -> offlineAsrRecognizer?.addAudioData(processedAudio)
                 ActiveAsrEngine.NONE -> Unit
             }
@@ -221,8 +229,13 @@ class AecVoiceCallAudioManager(
         )
 
         if (isRecording) {
-            Log.w(TAG, "已经在录音中，忽略此次请求")
-            return
+            if (activeAsrEngine != ActiveAsrEngine.NONE || recognitionActive) {
+                Log.w(TAG, "已经在录音中，忽略此次请求")
+                return
+            }
+            // 防止状态漂移：isRecording=true 但引擎已停，允许本次重新启动
+            Log.w(TAG, "检测到录音状态漂移，重置后重新启动录音")
+            isRecording = false
         }
 
         // 检查录音权限
@@ -285,6 +298,7 @@ class AecVoiceCallAudioManager(
                 isStopping = false
                 shouldAutoResumeRecording = false
                 lastAudioTime = System.currentTimeMillis()
+                hasSpeechInCurrentTurn = false
                 activeAsrEngine = ActiveAsrEngine.OFFLINE
                 requestAudioFocus()
 
@@ -394,10 +408,8 @@ class AecVoiceCallAudioManager(
         onError: (String) -> Unit,
         onSilenceTimeout: () -> Unit
     ) {
-        // 初始化 SDK（只在客户端未初始化时才初始化）
         recordingJob = managerScope.launch {
             Log.d(TAG, "startRecording: 开始协程执行")
-            // 标准模式下，严格确保资源已释放；Persistent 模式下跳过等待 AudioRecord 完全释放
             if (!usePersistentAec) {
                 Log.d(TAG, "startRecording: 调用 ensureResourcesReleased()（标准模式）")
                 ensureResourcesReleased()
@@ -406,54 +418,41 @@ class AecVoiceCallAudioManager(
                 Log.d(TAG, "startRecording: Persistent AEC 模式，跳过 ensureResourcesReleased() 的录音释放等待")
             }
 
-            // 检查客户端是否已初始化
-            if (aecQwenSpeechClient == null || aecAudioProcessor == null) {
+            if (aecAudioProcessor == null) {
                 Log.d(TAG, "客户端未初始化，开始初始化")
                 initializeClients()
                 Log.d(TAG, "客户端初始化完成")
             }
 
-            val initResult = aecQwenSpeechClient?.initialize(context)
-            if (initResult?.isFailure == true) {
-                Log.e(TAG, "语音识别客户端初始化失败")
-                onError("语音识别客户端初始化失败")
+            val runtime = resolveOnlineAsrRuntime()
+            if (runtime == null) {
+                Log.e(TAG, "在线 ASR 配置不完整")
+                onError("在线 ASR 配置不完整，请检查语音服务商凭证")
                 return@launch
             }
 
-            isRecording = true
-            isStopping = false
-            shouldAutoResumeRecording = false
-            lastAudioTime = System.currentTimeMillis()
-            activeAsrEngine = ActiveAsrEngine.NONE
+                isRecording = true
+                isStopping = false
+                shouldAutoResumeRecording = false
+                lastAudioTime = System.currentTimeMillis()
+                hasSpeechInCurrentTurn = false
+                activeAsrEngine = ActiveAsrEngine.NONE
 
-            // 请求音频焦点
-            requestAudioFocus()
+                requestAudioFocus()
 
-            // 设置回调
-            aecQwenSpeechClient?.setCallbacks(
-                onPartialResult = { text ->
-                    Log.d(TAG, "部分识别结果: $text")
-
-                    // 检测到音频活动，重置静音计时器
-                    lastAudioTime = System.currentTimeMillis()
-
-                    // 尝试从 JSON 中提取纯文本
-                    val contentText = try {
-                        val json = JSON.parseObject(text)
-                        json.getString("text") ?: text
-                    } catch (e: Exception) {
-                        Log.w(TAG, "解析部分识别结果 JSON 失败，使用原始结果", e)
-                        text
+                val asrListener = object : AsrListener {
+                    override fun onPartial(text: String) {
+                        Log.d(TAG, "部分识别结果: $text")
+                        if (text.isNotBlank()) {
+                            hasSpeechInCurrentTurn = true
+                            lastAudioTime = System.currentTimeMillis()
+                        }
+                        onPartialResult(text)
                     }
 
-                    // 实时语音打断已经在 AecAudioProcessor 中实现，这里不需要再检测
-                    onPartialResult(contentText)
-                },
-                onFinalResult = { text ->
+                override fun onFinal(text: String) {
                     val thread = Thread.currentThread()
                     Log.d(TAG, "最终识别结果: $text, isStopping=$isStopping, thread=${thread.name}, isMain=${thread.name == "main"}")
-
-                    // 标记为正在停止，防止重复调用
                     isStopping = true
 
                     val guardedText = SpeechTextGuard.sanitizeFinalText(text)
@@ -468,19 +467,16 @@ class AecVoiceCallAudioManager(
                         VoiceTerminalMetrics.recordAsrFinalAccepted(
                             scene = metricsScene,
                             source = "cloud",
-                            textLength = guardedText.length
-                        )
+                                textLength = guardedText.length
+                            )
                     }
 
-                    Log.d(TAG, "调用外部 onFinalResult 回调: text=$text")
                     try {
                         onFinalResult(guardedText)
-                        Log.d(TAG, "外部 onFinalResult 回调调用完成")
                     } catch (e: Exception) {
                         Log.e(TAG, "调用外部 onFinalResult 回调失败", e)
                     }
 
-                    // 根据模式停止：标准模式停止录音 + AEC；Persistent 模式仅停止识别会话
                     Log.d(TAG, "准备停止录音/识别, usePersistentAec=$usePersistentAec")
                     CoroutineScope(Dispatchers.IO).launch {
                         if (usePersistentAec) {
@@ -490,11 +486,10 @@ class AecVoiceCallAudioManager(
                         }
                         Log.d(TAG, "录音/识别已停止, usePersistentAec=$usePersistentAec")
                     }
-                },
-                onError = { error ->
-                    Log.e(TAG, "录音错误: ${error.message}")
+                }
 
-                    // 标记为正在停止
+                override fun onError(error: String) {
+                    Log.e(TAG, "录音错误: $error")
                     isStopping = true
 
                     if (usePersistentAec) {
@@ -503,11 +498,14 @@ class AecVoiceCallAudioManager(
                         stopRecording()
                     }
 
-                    onError(error.message ?: "录音错误")
+                    onError(error)
                 }
-            )
+            }
 
-            // 启动/启用 AEC
+            cloudAsrEngine?.release()
+            cloudAsrEngine = createOnlineAsrEngine(runtime, asrListener)
+            cloudPcmConsumer = cloudAsrEngine as? ExternalPcmConsumer
+
             if (usePersistentAec) {
                 Log.d(TAG, "Persistent AEC 模式：ensureAecStarted + enableOutput")
                 ensureAecStarted()
@@ -519,15 +517,13 @@ class AecVoiceCallAudioManager(
                 aecAudioProcessor?.startRecording()
                 Log.d(TAG, "AEC 音频处理器已启动")
             }
-            
-            // 等待一小段时间，确保 AudioRecord 已经开始录音
+
             delay(100)
 
-            // 再启动语音识别
             Log.d(TAG, "启动语音识别")
-            val startResult = aecQwenSpeechClient?.startRecognition()
-            if (startResult?.isFailure == true) {
-                Log.e(TAG, "启动语音识别失败: ${startResult.exceptionOrNull()?.message}")
+            cloudAsrEngine?.start()
+            if (cloudAsrEngine?.isRunning != true) {
+                Log.e(TAG, "启动语音识别失败: ASR 引擎未运行")
                 onError("启动语音识别失败")
                 stopRecording()
                 return@launch
@@ -535,7 +531,6 @@ class AecVoiceCallAudioManager(
             Log.d(TAG, "语音识别已启动")
             activeAsrEngine = ActiveAsrEngine.CLOUD
 
-            // 启动静音检测
             startSilenceDetection(onSilenceTimeout)
             Log.d(TAG, "静音检测已启动")
         }
@@ -564,7 +559,8 @@ class AecVoiceCallAudioManager(
         aecAudioProcessor?.disableOutput()
 
         // 停止语音识别
-        aecQwenSpeechClient?.stopRecognition()
+        cloudAsrEngine?.stop()
+        cloudPcmConsumer = null
 
         Log.d(TAG, "Persistent AEC 模式：已停止识别 Session，底层 AEC 仍在运行")
     }
@@ -581,6 +577,21 @@ class AecVoiceCallAudioManager(
 
                 val currentTime = System.currentTimeMillis()
                 val silenceDuration = currentTime - lastAudioTime
+
+                // 云识别场景：检测到用户已说话后，静音一段时间自动结束本句并提交 final
+                if (
+                    activeAsrEngine == ActiveAsrEngine.CLOUD &&
+                    hasSpeechInCurrentTurn &&
+                    silenceDuration > CLOUD_UTTERANCE_SILENCE_MS
+                ) {
+                    Log.d(
+                        TAG,
+                        "云识别检测到单句结束（静音 ${silenceDuration}ms），自动结束当前识别会话"
+                    )
+                    isStopping = true
+                    stopRecording()
+                    break
+                }
 
                 // 如果静音时间超过阈值，自动停止录音并挂机
                 if (silenceDuration > SILENCE_DURATION_MS) {
@@ -611,6 +622,7 @@ class AecVoiceCallAudioManager(
             val shouldCancel = isStopping
             isRecording = false
             recognitionActive = false
+            hasSpeechInCurrentTurn = false
             silenceTimer?.cancel()
             silenceTimer = null
             activeAsrEngine = ActiveAsrEngine.NONE
@@ -647,6 +659,7 @@ class AecVoiceCallAudioManager(
         // 标准模式：保持原有行为，完全停止录音和 AEC
         isRecording = false
         isStopping = true
+        hasSpeechInCurrentTurn = false
 
         // 停止静音检测
         silenceTimer?.cancel()
@@ -656,7 +669,8 @@ class AecVoiceCallAudioManager(
         aecAudioProcessor?.stopRecording()
 
         // 停止语音识别（异步，不等待）
-        aecQwenSpeechClient?.stopRecognition()
+        cloudAsrEngine?.stop()
+        cloudPcmConsumer = null
         activeAsrEngine = ActiveAsrEngine.NONE
 
         // 等待一小段时间，确保 AudioRecord 已被释放
@@ -761,89 +775,117 @@ class AecVoiceCallAudioManager(
             // 收集完整的文本
             val fullText = StringBuilder()
             var chunkCount = 0
+            var streamError: String? = null
 
             // 使用协程并发处理：一边 collect 文本块，一边发送给 TTS
             val collectJob = managerScope.launch {
                 try {
                     textFlow.collect { chunk ->
+                        if (streamError != null) return@collect
+
                         chunkCount++
                         Log.d(TAG, "收到文本块 #$chunkCount: ${chunk.take(50)}...")
                         fullText.append(chunk)
 
                         // 发送文本块到流式 TTS
                         val sendResult = cosyVoiceTTSClient?.sendStreamingChunk(chunk)
-                        if (sendResult?.isFailure == true) {
-                            Log.e(TAG, "发送文本块到流式 TTS 失败")
-                            onError("发送文本块失败")
+                            ?: Result.failure(IllegalStateException("TTS 客户端未初始化"))
+                        if (sendResult.isFailure) {
+                            streamError = sendResult.exceptionOrNull()?.message ?: "发送文本块失败"
+                            Log.e(TAG, "发送文本块到流式 TTS 失败: $streamError")
                             return@collect
                         }
                     }
                     Log.d(TAG, "textFlow.collect 完成，共收到 $chunkCount 个文本块")
 
+                    if (streamError != null) return@launch
+
                     // 所有文本块已发送，结束流式会话
                     Log.d(TAG, "所有文本块已发送，结束流式会话")
                     val finishResult = cosyVoiceTTSClient?.finishStreamingSession()
-                    if (finishResult?.isFailure == true) {
-                        Log.e(TAG, "结束流式 TTS 会话失败")
-                        onError("结束流式 TTS 会话失败")
+                        ?: Result.failure(IllegalStateException("TTS 客户端未初始化"))
+                    if (finishResult.isFailure) {
+                        streamError = finishResult.exceptionOrNull()?.message ?: "结束流式 TTS 会话失败"
+                        Log.e(TAG, "结束流式 TTS 会话失败: $streamError")
                         return@launch
                     }
                     Log.d(TAG, "finish-task 已发送")
                 } catch (e: Exception) {
                     Log.e(TAG, "collect 文本块异常", e)
-                    onError(e.message ?: "collect 文本块异常")
+                    if (streamError == null) {
+                        streamError = e.message ?: "collect 文本块异常"
+                    }
                 }
             }
 
             // 等待 collect 完成（文本块发送完成）
             collectJob.join()
 
-            Log.d(TAG, "等待音频数据播放完成...")
+            if (streamError != null) {
+                Log.e(TAG, "流式 TTS 会话提前失败: $streamError")
+                aecAudioProcessor?.notifyPlaybackStopped()
+                isPlaying = false
+                onError(streamError ?: "流式 TTS 播放失败")
+                cosyVoiceTTSClient?.stopStreamingSession()
+                return
+            }
 
-            // 等待播放完成，超时时间为 30 秒
-            var waitCount = 0
-            val maxWaitCount = 300  // 30 秒
-            while (cosyVoiceTTSClient?.isStreamingActive() == true && waitCount < maxWaitCount) {
+            Log.d(TAG, "等待流式会话收敛与音频播放完成...")
+
+            // 某些机型/网络下，服务端状态位会晚于音频结束；避免因为状态位滞后卡住下一轮录音
+            var settleWaitMs = 0L
+            var streamOnlyMs = 0L
+            while (settleWaitMs < STREAM_SETTLE_TIMEOUT_MS) {
+                val streamActive = cosyVoiceTTSClient?.isStreamingActive() == true
+                val audioPlaying = cosyVoiceTTSClient?.isAudioTrackStillPlaying() == true
+
+                if (!streamActive && !audioPlaying) {
+                    break
+                }
+
+                if (streamActive && !audioPlaying) {
+                    streamOnlyMs += 100L
+                    if (streamOnlyMs >= STREAM_ONLY_GRACE_MS) {
+                        Log.w(TAG, "音频已结束但流式状态未关闭，提前收敛会话")
+                        break
+                    }
+                } else {
+                    streamOnlyMs = 0L
+                }
+
                 delay(100)
-                waitCount++
-                if (waitCount % 50 == 0) {
-                    Log.d(TAG, "等待音频数据... waitCount=$waitCount/${maxWaitCount}")
+                settleWaitMs += 100L
+                if (settleWaitMs % 1000L == 0L) {
+                    Log.d(TAG, "等待流式收敛... ${settleWaitMs}ms/${STREAM_SETTLE_TIMEOUT_MS}ms")
                 }
             }
-
-            if (waitCount >= maxWaitCount) {
-                Log.w(TAG, "等待音频数据超时")
-            } else {
-                Log.d(TAG, "音频数据播放完成")
+            if (settleWaitMs >= STREAM_SETTLE_TIMEOUT_MS) {
+                Log.w(TAG, "等待流式收敛超时，继续后续流程")
             }
 
-            // 额外等待 AudioTrack 播放完缓冲区的数据
-            Log.d(TAG, "流式会话已完成，等待 AudioTrack 播放完缓冲区...")
-            var audioWaitCount = 0
-            val maxAudioWaitCount = 100  // 10 秒
-            while (cosyVoiceTTSClient?.isAudioTrackStillPlaying() == true && audioWaitCount < maxAudioWaitCount) {
+            // 再短暂等待 AudioTrack 缓冲区排空，避免截断尾音
+            var audioDrainMs = 0L
+            while (
+                cosyVoiceTTSClient?.isAudioTrackStillPlaying() == true &&
+                audioDrainMs < STREAM_AUDIO_DRAIN_TIMEOUT_MS
+            ) {
                 delay(100)
-                audioWaitCount++
-                if (audioWaitCount % 50 == 0) {
-                    Log.d(TAG, "等待 AudioTrack 播放... audioWaitCount=$audioWaitCount/${maxAudioWaitCount}")
-                }
+                audioDrainMs += 100L
             }
-
-            if (audioWaitCount >= maxAudioWaitCount) {
-                Log.w(TAG, "等待 AudioTrack 播放超时")
+            if (audioDrainMs >= STREAM_AUDIO_DRAIN_TIMEOUT_MS) {
+                Log.w(TAG, "等待 AudioTrack 排空超时，继续后续流程")
             } else {
                 Log.d(TAG, "AudioTrack 播放完成")
             }
 
             Log.d(TAG, "流式 TTS 播放完成")
+            // 正常完成后主动收尾流式会话，确保状态位归零
+            cosyVoiceTTSClient?.stopStreamingSession()
             // 通知 AEC 处理器 TTS 播放已停止
             aecAudioProcessor?.notifyPlaybackStopped()
             // 先更新状态，再调用完成回调，避免状态不一致
             isPlaying = false
             onFinished(fullText.toString())
-
-            // 正常完成后停止流式会话
-           // cosyVoiceTTSClient?.stopStreamingSession()
 
         } catch (e: Exception) {
             Log.e(TAG, "流式 TTS 播放异常", e)
@@ -924,14 +966,15 @@ class AecVoiceCallAudioManager(
         abandonAudioFocus()
 
         // 释放客户端
-        aecQwenSpeechClient?.release()
+        cloudAsrEngine?.release()
         offlineAsrRecognizer?.cancelListening()
         offlineAsrRecognizer?.destroy()
         aecAudioProcessor?.release()
-        cosyVoiceTTSClient?.cancelPlayback()
+        cosyVoiceTTSClient?.release()
 
         // 清空引用
-        aecQwenSpeechClient = null
+        cloudAsrEngine = null
+        cloudPcmConsumer = null
         offlineAsrRecognizer = null
         aecAudioProcessor = null
         cosyVoiceTTSClient = null
@@ -1027,6 +1070,70 @@ class AecVoiceCallAudioManager(
             context.checkSelfPermission(Manifest.permission.RECORD_AUDIO)
     }
 
+    private data class OnlineAsrRuntime(
+        val provider: SpeechProvider,
+        val config: AsrConfig
+    )
+
+    private fun resolveOnlineAsrRuntime(): OnlineAsrRuntime? {
+        val settings = settingsManager.settings.value
+        val provider = settings.speechProvider
+        val providerConfig = SpeechProviderConfig.get(provider)
+        val credentials = settingsManager.getSpeechCredentials(provider)
+        val speechModels = settingsManager.getSpeechModels(provider)
+
+        val resolvedApiKey = credentials.apiKey.ifBlank { apiKey }
+        val resolvedModel = speechModels.asrModel.ifEmpty { providerConfig.asrDefaultModel }
+        val resolvedResourceId = if (provider == SpeechProvider.VOLCANO) {
+            if (resolvedModel.startsWith("volc.", ignoreCase = true)) resolvedModel else ""
+        } else {
+            credentials.asrResourceId
+        }
+
+        val config = AsrConfig(
+            apiKey = resolvedApiKey,
+            model = resolvedModel,
+            language = "zh",
+            appId = credentials.appId,
+            cluster = credentials.cluster,
+            resourceId = resolvedResourceId
+        )
+
+        return when (provider) {
+            SpeechProvider.BAILIAN -> {
+                if (config.apiKey.isBlank()) null else OnlineAsrRuntime(provider, config)
+            }
+
+            SpeechProvider.VOLCANO -> {
+                if (config.apiKey.isBlank() || config.appId.isBlank() || config.resourceId.isBlank()) {
+                    null
+                } else {
+                    OnlineAsrRuntime(provider, config)
+                }
+            }
+        }
+    }
+
+    private fun createOnlineAsrEngine(runtime: OnlineAsrRuntime, listener: AsrListener): AsrEngine {
+        return when (runtime.provider) {
+            SpeechProvider.BAILIAN -> BailianAsrEngine(
+                config = runtime.config,
+                context = context,
+                scope = managerScope,
+                listener = listener,
+                externalPcmMode = true
+            )
+
+            SpeechProvider.VOLCANO -> VolcanoAsrEngine(
+                config = runtime.config,
+                context = context,
+                scope = managerScope,
+                listener = listener,
+                externalPcmMode = true
+            )
+        }
+    }
+
     /**
      * 确保资源已完全释放
      * 在重新初始化前调用，避免资源冲突
@@ -1057,10 +1164,11 @@ class AecVoiceCallAudioManager(
     private fun checkResourcesReleased(): Boolean {
         val recordingState = aecAudioProcessor?.isCurrentlyRecording() != true
         val offlineState = offlineAsrRecognizer?.isCurrentlyListening() != true
-        val clientState = !isRecording && !recognitionActive && activeAsrEngine == ActiveAsrEngine.NONE
+        val cloudState = cloudAsrEngine?.isRunning != true
+        val clientState = !isRecording && !recognitionActive && activeAsrEngine == ActiveAsrEngine.NONE && cloudState
         Log.d(
             TAG,
-            "checkResourcesReleased: recordingState=$recordingState, offlineState=$offlineState, clientState=$clientState"
+            "checkResourcesReleased: recordingState=$recordingState, offlineState=$offlineState, cloudState=$cloudState, clientState=$clientState"
         )
         return recordingState && offlineState && clientState
     }
@@ -1082,6 +1190,6 @@ class AecVoiceCallAudioManager(
     }
 
     private fun shouldFallbackToCloud(): Boolean {
-        return offlineAsrAutoFallbackToCloud && apiKey.isNotBlank()
+        return offlineAsrAutoFallbackToCloud && resolveOnlineAsrRuntime() != null
     }
 }

--- a/app/src/main/java/com/alian/assistant/infrastructure/audio/VoiceCallAudioManager.kt
+++ b/app/src/main/java/com/alian/assistant/infrastructure/audio/VoiceCallAudioManager.kt
@@ -5,13 +5,19 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioManager
 import android.util.Log
-import com.alibaba.fastjson.JSON
 import com.alian.assistant.common.utils.SpeechTextGuard
 import com.alian.assistant.common.utils.VoiceTerminalMetrics
 import com.alian.assistant.data.SettingsManager
+import com.alian.assistant.data.model.SpeechProvider
+import com.alian.assistant.data.model.SpeechProviderConfig
+import com.alian.assistant.infrastructure.ai.asr.AsrConfig
+import com.alian.assistant.infrastructure.ai.asr.AsrEngine
+import com.alian.assistant.infrastructure.ai.asr.AsrListener
 import com.alian.assistant.infrastructure.ai.asr.SherpaOfflineSpeechRecognizer
-import com.alian.assistant.infrastructure.ai.asr.QwenSpeechClient
+import com.alian.assistant.infrastructure.ai.asr.bailian.BailianAsrEngine
+import com.alian.assistant.infrastructure.ai.asr.volcano.VolcanoAsrEngine
 import com.alian.assistant.infrastructure.ai.tts.HybridTtsClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -19,11 +25,10 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * 语音通话音频管理器
- * 管理录音和播放功能，复用现有的 QwenSpeechClient 和 TTS 客户端
+ * 管理录音和播放功能，支持按语音服务商切换在线 ASR/TTS。
  */
 class VoiceCallAudioManager(
     private val context: Context,
@@ -37,13 +42,14 @@ class VoiceCallAudioManager(
     companion object {
         private const val TAG = "VoiceCallAudioManager"
         private const val SILENCE_DURATION_MS = Long.MAX_VALUE  // 静音持续时间（毫秒），禁用静音超时检测
+        private const val CLOUD_UTTERANCE_SILENCE_MS = 1500L    // 云识别单句静音收尾阈值
     }
 
     // 音频管理器
     private val audioManager: AudioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
-    // 语音识别客户端
-    private var qwenSpeechClient: QwenSpeechClient? = null
+    // 在线语音识别引擎
+    private var onlineAsrEngine: AsrEngine? = null
     private var offlineAsrRecognizer: SherpaOfflineSpeechRecognizer? = null
 
     // 语音合成客户端
@@ -66,6 +72,8 @@ class VoiceCallAudioManager(
 
     // 最后一次检测到音频的时间
     private var lastAudioTime: Long = 0
+    // 当前轮次是否已检测到有效说话内容（用于云识别单句自动收尾）
+    private var hasSpeechInCurrentTurn: Boolean = false
 
     // 统一的协程作用域，用于管理所有协程
     private val managerJob = SupervisorJob()
@@ -99,27 +107,20 @@ class VoiceCallAudioManager(
     /**
      * 初始化客户端
      */
-    private fun initializeClients() {
-        // 初始化语音识别客户端
-        qwenSpeechClient = QwenSpeechClient(
-            apiKey = apiKey,
-            url = "wss://dashscope.aliyuncs.com/api-ws/v1/inference",
-            model = "fun-asr-realtime-2025-09-15",
-            sampleRate = 16000,
-            audioFormat = "pcm",
-            vadEnabled = true
-        )
-
-        // 初始化语音合成客户端
-        cosyVoiceTTSClient = HybridTtsClient(
-            appContext = context,
-            apiKey = apiKey,
-            voice = ttsVoice,
-            rate = ttsSpeed,
-            volume = volume,
-            offlineTtsEnabled = offlineTtsEnabled,
-            offlineTtsAutoFallbackToCloud = offlineTtsAutoFallbackToCloud
-        )
+    private fun initializeClients(forceRecreateTts: Boolean = false) {
+        // TTS 客户端只在首次/显式重建时创建，避免每轮对话重复 new 导致资源累积
+        if (forceRecreateTts || cosyVoiceTTSClient == null) {
+            cosyVoiceTTSClient?.release()
+            cosyVoiceTTSClient = HybridTtsClient(
+                appContext = context,
+                apiKey = apiKey,
+                voice = ttsVoice,
+                rate = ttsSpeed,
+                volume = volume,
+                offlineTtsEnabled = offlineTtsEnabled,
+                offlineTtsAutoFallbackToCloud = offlineTtsAutoFallbackToCloud
+            )
+        }
 
         Log.d(TAG, "客户端初始化完成")
     }
@@ -141,8 +142,13 @@ class VoiceCallAudioManager(
         Log.d(TAG, "开始录音, useOfflineAsr=$useOfflineAsr")
 
         if (isRecording) {
-            Log.w(TAG, "已经在录音中，忽略此次请求")
-            return
+            if (activeAsrEngine != ActiveAsrEngine.NONE) {
+                Log.w(TAG, "已经在录音中，忽略此次请求")
+                return
+            }
+            // 防止状态漂移：isRecording=true 但引擎已停，允许本次重新启动
+            Log.w(TAG, "检测到录音状态漂移，重置后重新启动录音")
+            isRecording = false
         }
 
         // 检查录音权限
@@ -184,7 +190,7 @@ class VoiceCallAudioManager(
                     Log.e(TAG, "离线 ASR 初始化失败")
                     isRecording = false
                     activeAsrEngine = ActiveAsrEngine.NONE
-                    if (offlineAsrAutoFallbackToCloud && apiKey.isNotBlank()) {
+                    if (offlineAsrAutoFallbackToCloud && resolveOnlineAsrRuntime() != null) {
                         Log.w(TAG, "离线 ASR 初始化失败，回退在线 ASR")
                         startOnlineRecording(
                             onPartialResult = onPartialResult,
@@ -201,6 +207,7 @@ class VoiceCallAudioManager(
                 isRecording = true
                 isStopping = false
                 lastAudioTime = System.currentTimeMillis()
+                hasSpeechInCurrentTurn = false
                 requestAudioFocus()
                 activeAsrEngine = ActiveAsrEngine.OFFLINE
 
@@ -244,7 +251,7 @@ class VoiceCallAudioManager(
                             Log.e(TAG, "离线 ASR 错误: $message")
                             isStopping = true
                             stopRecording()
-                            if (offlineAsrAutoFallbackToCloud && apiKey.isNotBlank()) {
+                            if (offlineAsrAutoFallbackToCloud && resolveOnlineAsrRuntime() != null) {
                                 startOnlineRecording(
                                     onPartialResult = onPartialResult,
                                     onFinalResult = onFinalResult,
@@ -261,7 +268,7 @@ class VoiceCallAudioManager(
                 if (!started) {
                     isRecording = false
                     activeAsrEngine = ActiveAsrEngine.NONE
-                    if (offlineAsrAutoFallbackToCloud && apiKey.isNotBlank()) {
+                    if (offlineAsrAutoFallbackToCloud && resolveOnlineAsrRuntime() != null) {
                         Log.w(TAG, "离线 ASR 启动失败，回退在线 ASR")
                         startOnlineRecording(
                             onPartialResult = onPartialResult,
@@ -276,6 +283,9 @@ class VoiceCallAudioManager(
                 }
 
                 startSilenceDetection(onSilenceTimeout)
+            } catch (e: CancellationException) {
+                Log.d(TAG, "离线录音启动任务已取消")
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "离线录音启动异常", e)
                 isRecording = false
@@ -291,65 +301,53 @@ class VoiceCallAudioManager(
         onError: (String) -> Unit,
         onSilenceTimeout: () -> Unit
     ) {
-        // 在 IO 线程中启动录音，确保上一次的 AudioRecord 已完全释放
         recordingJob = managerScope.launch {
             try {
-                // 确保资源已完全释放
                 ensureResourcesReleased()
-
-                // 等待一小段时间，确保上一次的 AudioRecord 已完全释放
-                // 这可以避免在快速停止和重新开始录音时出现麦克风错误
                 delay(200)
 
-                // 重新初始化语音识别客户端（因为每次停止录音后都会释放资源）
-                initializeClients()
+                if (cosyVoiceTTSClient == null) {
+                    initializeClients()
+                }
+
+                val runtime = resolveOnlineAsrRuntime()
+                if (runtime == null) {
+                    isRecording = false
+                    activeAsrEngine = ActiveAsrEngine.NONE
+                    onError("在线 ASR 配置不完整，请在语音服务商页检查凭证")
+                    return@launch
+                }
 
                 isRecording = true
                 isStopping = false
                 lastAudioTime = System.currentTimeMillis()
+                hasSpeechInCurrentTurn = false
                 activeAsrEngine = ActiveAsrEngine.NONE
 
-                // 请求音频焦点
                 requestAudioFocus()
 
-                // 设置回调
-                qwenSpeechClient?.setCallbacks(
-                    onPartialResult = { text ->
+                val asrListener = object : AsrListener {
+                    override fun onPartial(text: String) {
                         Log.d(TAG, "部分识别结果: $text")
-
-                        // 如果正在播放 TTS，忽略语音识别结果（避免录制到 TTS 播放的声音）
                         if (isPlaying) {
                             Log.d(TAG, "正在播放 TTS，忽略语音识别结果")
-                            return@setCallbacks
+                            return
                         }
-
-                        // 检测到音频活动，重置静音计时器
-                        lastAudioTime = System.currentTimeMillis()
-
-                        // 尝试从 JSON 中提取纯文本
-                        val contentText = try {
-                            val json = JSON.parseObject(text)
-                            json.getString("text") ?: text
-                        } catch (e: Exception) {
-                            Log.w(TAG, "解析部分识别结果 JSON 失败，使用原始结果", e)
-                            text
+                        if (text.isNotBlank()) {
+                            hasSpeechInCurrentTurn = true
+                            lastAudioTime = System.currentTimeMillis()
                         }
+                        onPartialResult(text)
+                    }
 
-                        onPartialResult(contentText)
-                    },
-                    onFinalResult = { text ->
+                    override fun onFinal(text: String) {
                         Log.d(TAG, "最终识别结果: $text")
-
-                        // 如果正在播放 TTS，忽略语音识别结果
                         if (isPlaying) {
                             Log.d(TAG, "正在播放 TTS，忽略语音识别结果")
-                            return@setCallbacks
+                            return
                         }
 
-                        // 标记为正在停止，防止重复调用
                         isStopping = true
-
-                        // 停止录音
                         stopRecording()
 
                         val guardedText = SpeechTextGuard.sanitizeFinalText(text)
@@ -368,41 +366,38 @@ class VoiceCallAudioManager(
                             )
                         }
                         onFinalResult(guardedText)
-                    },
-                    onError = { error ->
-                        Log.e(TAG, "录音错误: ${error.message}")
-
-                        // 标记为正在停止
-                        isStopping = true
-
-                        stopRecording()
-
-                        onError(error.message ?: "录音错误")
                     }
-                )
 
-                // 切换到主线程启动语音识别
-                withContext(Dispatchers.Main) {
-                    val result = qwenSpeechClient?.recognizeSpeechRealTime(context)
-
-                    if (result?.isFailure == true) {
-                        val error = result.exceptionOrNull()
-                        Log.e(TAG, "录音启动失败: ${error?.message}")
-                        isRecording = false
-                        activeAsrEngine = ActiveAsrEngine.NONE
-                        onError(error?.message ?: "录音启动失败")
+                    override fun onError(error: String) {
+                        Log.e(TAG, "录音错误: $error")
+                        isStopping = true
+                        stopRecording()
+                        onError(error)
                     }
                 }
+
+                onlineAsrEngine?.release()
+                onlineAsrEngine = createOnlineAsrEngine(runtime, asrListener)
+                onlineAsrEngine?.start()
 
                 if (!isRecording) {
                     return@launch
                 }
 
-                activeAsrEngine = ActiveAsrEngine.CLOUD
+                if (onlineAsrEngine?.isRunning != true) {
+                    Log.e(TAG, "录音启动失败: ASR 引擎未运行")
+                    isRecording = false
+                    activeAsrEngine = ActiveAsrEngine.NONE
+                    onError("录音启动失败")
+                    return@launch
+                }
 
-                // 启动静音检测
+                activeAsrEngine = ActiveAsrEngine.CLOUD
                 startSilenceDetection(onSilenceTimeout)
 
+            } catch (e: CancellationException) {
+                Log.d(TAG, "在线录音启动任务已取消")
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "录音启动异常", e)
                 isRecording = false
@@ -430,6 +425,21 @@ class VoiceCallAudioManager(
                 val currentTime = System.currentTimeMillis()
                 val silenceDuration = currentTime - lastAudioTime
 
+                // 云识别场景：检测到用户已说话后，静音一段时间自动结束本句并提交 final
+                if (
+                    activeAsrEngine == ActiveAsrEngine.CLOUD &&
+                    hasSpeechInCurrentTurn &&
+                    silenceDuration > CLOUD_UTTERANCE_SILENCE_MS
+                ) {
+                    Log.d(
+                        TAG,
+                        "云识别检测到单句结束（静音 ${silenceDuration}ms），自动结束当前识别会话"
+                    )
+                    isStopping = true
+                    stopRecording()
+                    break
+                }
+
                 // 如果静音时间超过阈值，自动停止录音并挂机
                 if (silenceDuration > SILENCE_DURATION_MS) {
                     Log.d(TAG, "检测到静音超过 ${SILENCE_DURATION_MS}ms，自动停止录音并挂机")
@@ -455,6 +465,7 @@ class VoiceCallAudioManager(
 
         // 标记为不在录音
         isRecording = false
+        hasSpeechInCurrentTurn = false
 
         // 停止静音检测
         silenceTimer?.cancel()
@@ -479,7 +490,7 @@ class VoiceCallAudioManager(
                     }
 
                     ActiveAsrEngine.CLOUD -> {
-                        qwenSpeechClient?.stopRecognition()
+                        onlineAsrEngine?.stop()
                         Log.d(TAG, "在线语音识别已停止")
                     }
 
@@ -525,12 +536,6 @@ class VoiceCallAudioManager(
         val wasRecording = isRecording
         if (!ttsInterruptEnabled && wasRecording) {
             Log.d(TAG, "未启用实时语音打断，播放 TTS 时停止录音")
-            // 清除所有回调，避免录音停止后的识别结果干扰
-            qwenSpeechClient?.setCallbacks(
-                onPartialResult = null,
-                onFinalResult = null,
-                onError = null
-            )
             stopRecording()
         }
 
@@ -634,36 +639,31 @@ class VoiceCallAudioManager(
         abandonAudioFocus()
 
         // 释放客户端（先保存引用，避免在释放过程中被设置为 null）
-        val speechClient = qwenSpeechClient
+        val speechEngine = onlineAsrEngine
         val offlineRecognizer = offlineAsrRecognizer
         val ttsClient = cosyVoiceTTSClient
 
         // 清空引用
-        qwenSpeechClient = null
+        onlineAsrEngine = null
         offlineAsrRecognizer = null
         cosyVoiceTTSClient = null
         activeAsrEngine = ActiveAsrEngine.NONE
 
-        // 在后台线程释放语音识别客户端，避免阻塞主线程
-        managerScope.launch {
-            try {
-                speechClient?.stopRecognition()
-                offlineRecognizer?.cancelListening()
-                offlineRecognizer?.destroy()
-                Log.d(TAG, "语音识别客户端已释放")
-            } catch (e: Exception) {
-                Log.e(TAG, "释放语音识别客户端失败", e)
-            }
+        // 同步释放，确保 release() 取消作用域前资源已经真正回收
+        try {
+            speechEngine?.release()
+            offlineRecognizer?.cancelListening()
+            offlineRecognizer?.destroy()
+            Log.d(TAG, "语音识别客户端已释放")
+        } catch (e: Exception) {
+            Log.e(TAG, "释放语音识别客户端失败", e)
         }
 
-        // 在后台线程释放语音合成客户端
-        managerScope.launch {
-            try {
-                ttsClient?.cancelPlayback()
-                Log.d(TAG, "语音合成客户端已释放")
-            } catch (e: Exception) {
-                Log.e(TAG, "释放语音合成客户端失败", e)
-            }
+        try {
+            ttsClient?.release()
+            Log.d(TAG, "语音合成客户端已释放")
+        } catch (e: Exception) {
+            Log.e(TAG, "释放语音合成客户端失败", e)
         }
 
         // 重置状态
@@ -758,6 +758,70 @@ class VoiceCallAudioManager(
         Log.d(TAG, "所有资源已释放")
     }
 
+    private data class OnlineAsrRuntime(
+        val provider: SpeechProvider,
+        val config: AsrConfig
+    )
+
+    private fun resolveOnlineAsrRuntime(): OnlineAsrRuntime? {
+        val settings = settingsManager.settings.value
+        val provider = settings.speechProvider
+        val providerConfig = SpeechProviderConfig.get(provider)
+        val credentials = settingsManager.getSpeechCredentials(provider)
+        val speechModels = settingsManager.getSpeechModels(provider)
+
+        val resolvedApiKey = credentials.apiKey.ifBlank { apiKey }
+        val resolvedModel = speechModels.asrModel.ifEmpty { providerConfig.asrDefaultModel }
+        val resolvedResourceId = if (provider == SpeechProvider.VOLCANO) {
+            if (resolvedModel.startsWith("volc.", ignoreCase = true)) resolvedModel else ""
+        } else {
+            credentials.asrResourceId
+        }
+
+        val config = AsrConfig(
+            apiKey = resolvedApiKey,
+            model = resolvedModel,
+            language = "zh",
+            appId = credentials.appId,
+            cluster = credentials.cluster,
+            resourceId = resolvedResourceId
+        )
+
+        return when (provider) {
+            SpeechProvider.BAILIAN -> {
+                if (config.apiKey.isBlank()) null else OnlineAsrRuntime(provider, config)
+            }
+
+            SpeechProvider.VOLCANO -> {
+                if (config.apiKey.isBlank() || config.appId.isBlank() || config.resourceId.isBlank()) {
+                    null
+                } else {
+                    OnlineAsrRuntime(provider, config)
+                }
+            }
+        }
+    }
+
+    private fun createOnlineAsrEngine(runtime: OnlineAsrRuntime, listener: AsrListener): AsrEngine {
+        return when (runtime.provider) {
+            SpeechProvider.BAILIAN -> BailianAsrEngine(
+                config = runtime.config,
+                context = context,
+                scope = managerScope,
+                listener = listener,
+                externalPcmMode = false
+            )
+
+            SpeechProvider.VOLCANO -> VolcanoAsrEngine(
+                config = runtime.config,
+                context = context,
+                scope = managerScope,
+                listener = listener,
+                externalPcmMode = false
+            )
+        }
+    }
+
     /**
      * 确保资源已完全释放
      * 在重新初始化前调用，避免资源冲突
@@ -787,6 +851,7 @@ class VoiceCallAudioManager(
     private fun checkResourcesReleased(): Boolean {
         return !isRecording &&
             activeAsrEngine == ActiveAsrEngine.NONE &&
+            onlineAsrEngine?.isRunning != true &&
             offlineAsrRecognizer?.isCurrentlyListening() != true
     }
 }

--- a/app/src/main/java/com/alian/assistant/presentation/ui/overlay/OverlayService.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/overlay/OverlayService.kt
@@ -851,7 +851,7 @@ class OverlayService : Service() {
     private fun updateTTSClient() {
         ttsClient?.release()
         ttsClient = null
-        if (ttsEnabled && (offlineTtsEnabled || ttsApiKey.isNotEmpty())) {
+        if (ttsEnabled) {
             ttsClient = HybridTtsClient(
                 appContext = this,
                 apiKey = ttsApiKey,

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/local/AlianLocalHistoryDrawer.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/local/AlianLocalHistoryDrawer.kt
@@ -90,21 +90,19 @@ fun AlianLocalHistoryDrawer(
 ) {
         val colors = BaoziTheme.colors
 
-    // 渐变背景 - 增强区分度，使用主题颜色
+    // 渐变背景与聊天历史抽屉保持一致，提升顶部列表项边界可见性
     val gradientBrush = Brush.verticalGradient(
         colors = if (colors.isDark) {
-            // 深色模式：抽屉背景更深，与卡片形成明显对比
             listOf(
                 colors.backgroundDrawer,
-                colors.background.copy(alpha = 0.9f),
+                colors.background,
                 colors.background.copy(alpha = 0.95f)
             )
         } else {
-            // 浅色模式：抽屉背景更浅，与卡片形成明显对比
             listOf(
-                colors.surfaceVariant,
+                colors.backgroundDrawer,
                 colors.background.copy(alpha = 0.98f),
-                colors.background
+                colors.background.copy(alpha = 0.96f)
             )
         }
     )

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/AlianSettingsContent.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/AlianSettingsContent.kt
@@ -39,6 +39,7 @@ import coil.compose.AsyncImage
 import com.alian.assistant.R
 import com.alian.assistant.data.AppSettings
 import com.alian.assistant.data.VoicePreset
+import com.alian.assistant.infrastructure.ai.provider.VoicePresetManager
 import com.alian.assistant.presentation.ui.theme.BaoziTheme
 import com.alian.assistant.common.utils.AvatarCacheManager
 import java.io.IOException
@@ -67,7 +68,11 @@ fun AlianSettingsContent(
     val coroutineScope = rememberCoroutineScope()
     
     // 获取当前语音音色的头像URL（用户没配置头像时使用）
-    val currentVoice = VoicePreset.findByVoiceParam(settings.ttsVoice)
+    val voicePresetManager = remember { VoicePresetManager.getInstance() }
+    val currentVoice = remember(settings.speechProvider, settings.ttsVoice) {
+        voicePresetManager.findByVoiceParam(settings.speechProvider, settings.ttsVoice)
+            ?: VoicePreset.findByVoiceParam(settings.ttsVoice)
+    }
     val voiceAvatarUrl = currentVoice?.avatarUrl
 
     // 音频播放状态

--- a/app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/SpeechProviderSettingsContent.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/SpeechProviderSettingsContent.kt
@@ -498,14 +498,25 @@ private fun ProviderCard(
                     )
                 }
 
-                if (config.requiresCluster) {
+                if (config.requiresAsrResourceId) {
                     Spacer(modifier = Modifier.height(12.dp))
                     CredentialField(
-                        label = "Cluster",
-                        value = credentials.cluster,
+                        label = "ASR Resource ID",
+                        value = credentials.asrResourceId,
                         isPassword = false,
-                        onValueChange = { onUpdateCredentials(credentials.copy(cluster = it)) },
-                        placeholder = "如: volcano_tts"
+                        onValueChange = { onUpdateCredentials(credentials.copy(asrResourceId = it)) },
+                        placeholder = "如: volc.seedasr.auc"
+                    )
+                }
+
+                if (config.requiresTtsResourceId) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    CredentialField(
+                        label = "TTS Resource ID",
+                        value = credentials.ttsResourceId,
+                        isPassword = false,
+                        onValueChange = { onUpdateCredentials(credentials.copy(ttsResourceId = it)) },
+                        placeholder = "如: seed-tts-2.0"
                     )
                 }
 

--- a/app/src/main/java/com/alian/assistant/presentation/viewmodel/AlianViewModel.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/viewmodel/AlianViewModel.kt
@@ -366,7 +366,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
     private fun updateTTSClient() {
         ttsClient?.release()
         ttsClient = null
-        if (ttsEnabled && (offlineTtsEnabled || apiKey.isNotBlank())) {
+        if (ttsEnabled) {
             ttsClient = HybridTtsClient(
                 appContext = context,
                 apiKey = apiKey,
@@ -1656,7 +1656,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
         val messageTimestamps = mutableMapOf<String, Long>()
         // 用于收集每个消息的附件
         val messageAttachments = mutableMapOf<String, MutableList<Attachment>>()
-        // plan_finished 先于 assistant 消息到达时，暂存附件并在下一条 assistant 消息写入时合并
+        // plan_finished 附件先暂存，优先挂到下一条 assistant；若没有下一条再兜底挂到最后一条 assistant
         val pendingAssistantAttachments = mutableListOf<Attachment>()
 
         fun mergeAttachments(
@@ -1684,13 +1684,12 @@ class AlianViewModel(private val context: Context) : ViewModel() {
             _unifiedChatTimeline.add(MessageItem(message))
         }
 
-        fun attachOrQueuePlanFinishedAttachments(attachments: List<Attachment>) {
-            if (attachments.isEmpty()) return
-
+        fun flushPendingAttachmentsToLastAssistant(reason: String) {
+            if (pendingAssistantAttachments.isEmpty()) return
             val lastAssistantIndex = _messages.indexOfLast { !it.isUser }
             if (lastAssistantIndex >= 0) {
                 val lastAssistant = _messages[lastAssistantIndex]
-                val merged = mergeAttachments(lastAssistant.attachments, attachments)
+                val merged = mergeAttachments(lastAssistant.attachments, pendingAssistantAttachments)
                 val updated = lastAssistant.copy(attachments = merged)
                 _messages[lastAssistantIndex] = updated
 
@@ -1700,11 +1699,20 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                 if (timelineIndex >= 0) {
                     _unifiedChatTimeline[timelineIndex] = MessageItem(updated)
                 }
-                Log.d("AlianViewModel", "plan_finished 附件已挂载到最后一条 assistant: ${attachments.size} 个")
-            } else {
-                pendingAssistantAttachments.addAll(attachments)
-                Log.d("AlianViewModel", "plan_finished 附件暂存，等待 assistant 消息: ${attachments.size} 个")
+                Log.d(
+                    "AlianViewModel",
+                    "plan_finished 暂存附件兜底挂载到最后一条 assistant: ${pendingAssistantAttachments.size} 个, reason=$reason"
+                )
+                pendingAssistantAttachments.clear()
             }
+        }
+
+        fun queuePlanFinishedAttachments(attachments: List<Attachment>) {
+            if (attachments.isEmpty()) return
+            val merged = mergeAttachments(pendingAssistantAttachments, attachments)
+            pendingAssistantAttachments.clear()
+            pendingAssistantAttachments.addAll(merged)
+            Log.d("AlianViewModel", "plan_finished 附件暂存，等待下一条 assistant 消息: ${attachments.size} 个")
         }
 
         var processedEventCount = 0
@@ -1718,6 +1726,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
 
                         if (messageData.role == "user" || messageData.role == "assistant") {
                             if (messageData.role == "user") {
+                                flushPendingAttachmentsToLastAssistant("before user message event")
                                 activePlanBubbleEventId = null
                                 activePlanBubbleTimestamp = null
                                 activePlanBoundaryUserMessageId = messageData.message_id
@@ -2020,6 +2029,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                     try {
                         val dataString = event.data.toJsonString()
                         val userData = json.decodeFromString<UserMessageData>(dataString)
+                        flushPendingAttachmentsToLastAssistant("before user_message event")
                         activePlanBubbleEventId = null
                         activePlanBubbleTimestamp = null
                         activePlanBoundaryUserMessageId = userData.message_id
@@ -2171,7 +2181,7 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                                 steps = uiSteps
                             )
                         )
-                        attachOrQueuePlanFinishedAttachments(planData.attachments ?: emptyList())
+                        queuePlanFinishedAttachments(planData.attachments ?: emptyList())
                     } catch (e: Exception) {
                         Log.e("AlianViewModel", "解析计划完成事件失败", e)
                     }
@@ -2265,6 +2275,9 @@ class AlianViewModel(private val context: Context) : ViewModel() {
                 ))
             }
         }
+
+        // 没有“下一条 assistant”可消费时，兜底挂到最后一条 assistant
+        flushPendingAttachmentsToLastAssistant("after session events processed")
 
         // 处理深度思考章节的剩余缓冲区内容
         _deepThinkingSections.forEach { section ->

--- a/app/src/main/java/com/alian/assistant/presentation/viewmodel/VoiceCallViewModel.kt
+++ b/app/src/main/java/com/alian/assistant/presentation/viewmodel/VoiceCallViewModel.kt
@@ -14,8 +14,11 @@ import com.alian.assistant.infrastructure.audio.VoiceCallAudioManager
 import com.alian.assistant.presentation.ui.screens.voicecall.MCPVoiceCallClient
 import com.alibaba.fastjson.JSON
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -78,10 +81,13 @@ class VoiceCallViewModel(private val context: Context) {
     private var currentJob: Job? = null
 
     // 协程作用域（用于管理所有协程）
-    private val viewModelScope = CoroutineScope(Dispatchers.Main)
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     // 是否正在处理消息（防止重复请求）
     private var isProcessing = false
+
+    // 通话是否处于激活状态（用于拦截挂断后的异步重入）
+    private var callActive = false
 
     // API 配置
     var apiKey: String = ""
@@ -150,14 +156,22 @@ class VoiceCallViewModel(private val context: Context) {
                 ttsSpeed = ttsSpeed,
                 ttsInterruptEnabled = ttsInterruptEnabled,
                 volume = volume,
-                metricsScene = "voice_call"
+                metricsScene = "voice_call",
+                usePersistentAec = ttsInterruptEnabled
             )
             // 设置播放中断回调
             aecManager.setOnPlaybackInterrupted {
-                Log.d(TAG, "播放被中断(语音打断),更新状态并开始录音")
-                _currentPlayingMessage.value = ""
-                _callState.value = VoiceCallState.Recording
-                startRecording()
+                viewModelScope.launch {
+                    if (!callActive || audioManager == null) {
+                        Log.d(TAG, "通话未激活，忽略播放中断回调")
+                        return@launch
+                    }
+                    Log.d(TAG, "播放被中断(语音打断),更新状态并开始录音")
+                    isProcessing = false
+                    _currentPlayingMessage.value = ""
+                    _callState.value = VoiceCallState.Recording
+                    startRecording()
+                }
             }
             aecManager
         } else {
@@ -180,6 +194,8 @@ class VoiceCallViewModel(private val context: Context) {
             systemPrompt = systemPrompt
         )
 
+        callActive = true
+
         // 开始录音
         startRecording()
     }
@@ -189,17 +205,21 @@ class VoiceCallViewModel(private val context: Context) {
      */
     fun stopCall() {
         Log.d(TAG, "结束通话")
-        
-        // 取消所有协程
+
+        callActive = false
+
+        // 取消所有协程（包括延迟重启录音任务）
         currentJob?.cancel()
         currentJob = null
+        viewModelScope.coroutineContext.cancelChildren()
 
         // 重置处理标志
         isProcessing = false
 
-        // 停止音频
-        audioManager?.stopAll()
+        // 释放音频（包含 stopAll + 内部作用域清理）
+        audioManager?.release()
         audioManager = null
+        voiceCallClient = null
 
         // 清空状态
         _callState.value = VoiceCallState.Idle
@@ -213,6 +233,11 @@ class VoiceCallViewModel(private val context: Context) {
      * 开始录音
      */
     private fun startRecording() {
+        if (!callActive || audioManager == null) {
+            Log.d(TAG, "通话未激活，跳过 startRecording")
+            return
+        }
+
         Log.d(TAG, "开始录音")
         
         // 先设置状态为 Recording
@@ -224,12 +249,20 @@ class VoiceCallViewModel(private val context: Context) {
 
         // 调用音频管理器开始录音
         audioManager?.startRecording(
-            onPartialResult = { text ->
+            onPartialResult = partial@{ text ->
+                if (!callActive || audioManager == null) {
+                    Log.d(TAG, "通话未激活，忽略部分识别结果")
+                    return@partial
+                }
                 // 实时显示识别结果（过滤 AI 回复）
                 val filteredText = filterOutAIResponse(text)
                 _currentRecognizedText.value = filteredText
             },
-            onFinalResult = { text ->
+            onFinalResult = final@{ text ->
+                if (!callActive || audioManager == null) {
+                    Log.d(TAG, "通话未激活，忽略最终识别结果")
+                    return@final
+                }
                 Log.d(TAG, "VoiceCallViewModel.onFinalResult 被调用: text='$text', isBlank=${text.isBlank()}")
                 // 识别完成，发送到 API
                 if (text.isNotBlank()) {
@@ -238,10 +271,14 @@ class VoiceCallViewModel(private val context: Context) {
                 } else {
                     // 如果没有识别到内容，继续录音
                     Log.d(TAG, "未识别到语音内容，继续录音")
-                    startRecording()
+                    restartRecordingWithDelay(0, "blank_asr_final")
                 }
             },
-            onError = { error ->
+            onError = errorCb@{ error ->
+                if (!callActive || audioManager == null || _callState.value is VoiceCallState.Idle) {
+                    Log.d(TAG, "通话未激活，忽略录音错误: $error")
+                    return@errorCb
+                }
                 Log.e(TAG, "录音错误: $error")
                 _callState.value = VoiceCallState.Error(error)
             },
@@ -418,6 +455,9 @@ class VoiceCallViewModel(private val context: Context) {
                 delay(2000)
                 startRecording()
             }
+        } catch (e: CancellationException) {
+            Log.d(TAG, "处理用户消息任务已取消")
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "处理用户消息失败", e)
             _callState.value = VoiceCallState.Error(e.message ?: "处理失败")
@@ -458,7 +498,11 @@ class VoiceCallViewModel(private val context: Context) {
             Log.d(TAG, "调用 audioManager.playTextStream...")
             audioManager?.playTextStream(
                 textFlow = textFlow,
-                onFinished = { fullText ->
+                onFinished = streamFinished@{ fullText ->
+                    if (!callActive || audioManager == null || _callState.value is VoiceCallState.Idle) {
+                        Log.d(TAG, "通话未激活，忽略流式播放完成回调")
+                        return@streamFinished
+                    }
                     Log.d(TAG, "流式播放完成，完整文本: $fullText")
 
                     // 添加助手消息到历史
@@ -477,33 +521,33 @@ class VoiceCallViewModel(private val context: Context) {
                     // 清空播放消息
                     _currentPlayingMessage.value = ""
 
-                    // 开始录音
-                    CoroutineScope(Dispatchers.IO).launch {
-                        delay(100)
-                        _callState.value = VoiceCallState.Recording
-                        startRecording()
-                    }
+                    // 流式场景下，尽早释放处理锁，避免“播放已结束但用户说话仍被判定为处理中”
+                    isProcessing = false
+
+                    restartRecordingWithDelay(100, "stream_finished")
                 },
-                onError = { error ->
+                onError = streamError@{ error ->
+                    if (!callActive || audioManager == null || _callState.value is VoiceCallState.Idle) {
+                        Log.d(TAG, "通话未激活，忽略流式播放错误: $error")
+                        return@streamError
+                    }
                     Log.e(TAG, "流式播放错误: $error")
                     _callState.value = VoiceCallState.Error(error)
                     _currentPlayingMessage.value = ""
+                    isProcessing = false
 
-                    // 等待 2 秒后重新开始录音
-                    CoroutineScope(Dispatchers.IO).launch {
-                        delay(2000)
-                        startRecording()
-                    }
+                    restartRecordingWithDelay(2000, "stream_playback_error")
                 }
             )
 
+        } catch (e: CancellationException) {
+            Log.d(TAG, "处理用户消息（流式）任务已取消")
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "处理用户消息（流式）失败", e)
             _callState.value = VoiceCallState.Error(e.message ?: "处理失败")
 
-            // 等待 2 秒后重新开始录音
-            delay(2000)
-            startRecording()
+            restartRecordingWithDelay(2000, "stream_process_exception")
         }
     }
 
@@ -518,7 +562,11 @@ class VoiceCallViewModel(private val context: Context) {
 
         audioManager?.playText(
             text = text,
-            onFinished = {
+            onFinished = playFinished@{
+                if (!callActive || audioManager == null || _callState.value is VoiceCallState.Idle) {
+                    Log.d(TAG, "通话未激活，忽略播放完成回调")
+                    return@playFinished
+                }
                 Log.d(TAG, "播放完成")
 
                 // 先清空播放消息
@@ -527,33 +575,38 @@ class VoiceCallViewModel(private val context: Context) {
                 // 检查是否还在播放(可能已经被语音打断)
                 if (audioManager?.isCurrentlyPlaying() == false) {
                     Log.d(TAG, "播放已被停止(可能是语音打断),立即开始录音")
-                    _callState.value = VoiceCallState.Recording
-                    startRecording()
+                    restartRecordingWithDelay(0, "playback_interrupted_or_stopped")
                 } else {
-                    // 正常完成播放,等待一小段时间后开始录音
-                    CoroutineScope(Dispatchers.IO).launch {
-                        delay(100)
-
-                        // 先更新状态为 Recording，确保状态转换正确
-                        _callState.value = VoiceCallState.Recording
-
-                        // 然后开始录音
-                        startRecording()
-                    }
+                    // 正常完成播放，等待一小段时间后开始录音
+                    restartRecordingWithDelay(100, "playback_finished")
                 }
             },
-            onError = { error ->
+            onError = playError@{ error ->
+                if (!callActive || audioManager == null || _callState.value is VoiceCallState.Idle) {
+                    Log.d(TAG, "通话未激活，忽略播放错误: $error")
+                    return@playError
+                }
                 Log.e(TAG, "播放错误: $error")
                 _callState.value = VoiceCallState.Error(error)
                 _currentPlayingMessage.value = ""
 
-                // 等待 2 秒后重新开始录音
-                CoroutineScope(Dispatchers.IO).launch {
-                    delay(2000)
-                    startRecording()
-                }
+                restartRecordingWithDelay(2000, "playback_error")
             }
         )
+    }
+
+    private fun restartRecordingWithDelay(delayMs: Long, reason: String) {
+        viewModelScope.launch {
+            if (delayMs > 0) {
+                delay(delayMs)
+            }
+            if (!callActive || audioManager == null || _callState.value is VoiceCallState.Idle) {
+                Log.d(TAG, "通话未激活，跳过重启录音: reason=$reason")
+                return@launch
+            }
+            _callState.value = VoiceCallState.Recording
+            startRecording()
+        }
     }
 
     /**

--- a/docs/volcano_speech_fix_plan.md
+++ b/docs/volcano_speech_fix_plan.md
@@ -1,0 +1,120 @@
+# 火山引擎 ASR/TTS 改造与修复文档（最终版）
+
+## 1. 目标
+
+本次改造目标：
+
+1. 在线 ASR/TTS 能按 `speechProvider` 在百炼与火山之间无缝切换。
+2. 火山实现完全对齐官方 v3 文档（Header 鉴权 + 二进制协议）。
+3. 修复配置层问题（`cluster` 误必填、缺少 resource id、凭证落盘不完整）。
+
+## 2. 官方文档基线（本次以此为准）
+
+- TTS（双向流）：`https://www.volcengine.com/docs/6561/1329505?lang=zh`
+- ASR（大模型流式）：`https://www.volcengine.com/docs/6561/1354869?lang=zh`
+
+关键结论：
+
+1. 火山 v3 使用 WebSocket Header 鉴权，不再依赖 URL query `cluster`。
+2. 必要 Header：
+   - `X-Api-App-Key`（APP ID）
+   - `X-Api-Access-Key`（Access Token）
+   - `X-Api-Resource-Id`（资源 ID）
+3. TTS/ASR 都是二进制协议，且整数字段为大端。
+
+## 3. 原始问题清单
+
+### 3.1 配置层
+
+1. 火山配置模型只覆盖 `appId/apiKey/cluster`，缺少 `ASR Resource ID` 和 `TTS Resource ID`。
+2. UI 把 `cluster` 当必填，与 v3 文档不一致。
+3. 凭证持久化未覆盖 resource id 字段。
+
+### 3.2 协议实现层
+
+1. `VolcanoAsrEngine` 仍是旧版 URL 参数鉴权和旧协议实现。
+2. `VolcanoTtsEngine` 仍是旧版 `api/v1/tts_binary_llm`，未实现 v3 事件流。
+3. 火山 ASR 工厂签名未跟上 `externalPcmMode`，会导致工厂接口不一致。
+
+### 3.3 运行时切换层
+
+1. 在线识别与通话链路大量写死 DashScope/Qwen。
+2. `HybridTtsClient` 在线分支只支持 CosyVoice，不支持火山。
+3. AEC 通话链路在线 ASR 写死 `AecQwenSpeechClient`。
+
+## 4. 改造设计
+
+### 4.1 配置模型
+
+- `SpeechProviderCredentials` 新增：
+  - `asrResourceId`
+  - `ttsResourceId`
+- `cluster` 保留为兼容字段，但不再作为火山运行时必填。
+- `SpeechProviderConfig` 增加 `requiresAsrResourceId / requiresTtsResourceId`。
+
+### 4.2 火山 ASR（v3）
+
+- 端点：
+  - `wss://openspeech.bytedance.com/api/v3/sauc/bigmodel`
+  - `.../bigmodel_nostream`
+  - `.../bigmodel_async`
+- Header 鉴权：`App-Key + Access-Key + Resource-Id`。
+- 首包发送 full client request。
+- 音频包发送 audio-only request（正序号），结束发送负序号 final 包。
+- 响应按二进制协议解析，支持 error frame/full server response。
+
+### 4.3 火山 TTS（v3 双向流）
+
+- 端点：`wss://openspeech.bytedance.com/api/v3/tts/bidirection`
+- Header 鉴权：`App-Key + Access-Key + Resource-Id`。
+- 会话流程：
+  - `StartConnection` -> `ConnectionStarted`
+  - `StartSession` -> `SessionStarted`
+  - `TaskRequest`（文本）
+  - `FinishSession` -> `SessionFinished`
+  - `FinishConnection`
+- 仅向上游回调 PCM 音频 payload，不再透传协议帧。
+
+### 4.4 在线链路切换
+
+- `StreamingVoiceRecognitionManager` 改为按 `speechProvider` 动态创建 `BailianAsrEngine/VolcanoAsrEngine`。
+- `VoiceCallAudioManager` 在线 ASR 改为统一 ASR 引擎。
+- `AecVoiceCallAudioManager` 在线 ASR 改为统一 ASR 引擎 + `ExternalPcmConsumer` 外部喂流。
+- `HybridTtsClient` 在线分支改为按 `speechProvider` 动态创建 `BailianTtsEngine/VolcanoTtsEngine`。
+
+## 5. 已完成修改（代码落地）
+
+1. 配置与持久化：
+   - `app/src/main/java/com/alian/assistant/data/model/SpeechProvider.kt`
+   - `app/src/main/java/com/alian/assistant/data/SettingsManager.kt`
+   - `app/src/main/java/com/alian/assistant/presentation/ui/screens/settings/SpeechProviderSettingsContent.kt`
+   - `app/src/main/java/com/alian/assistant/infrastructure/ai/provider/SpeechProviderManager.kt`
+
+2. 协议改造：
+   - `app/src/main/java/com/alian/assistant/infrastructure/ai/asr/volcano/VolcanoAsrEngine.kt`
+   - `app/src/main/java/com/alian/assistant/infrastructure/ai/tts/volcano/VolcanoTtsEngine.kt`
+
+3. 运行时在线切换：
+   - `app/src/main/java/com/alian/assistant/infrastructure/ai/asr/StreamingVoiceRecognitionManager.kt`
+   - `app/src/main/java/com/alian/assistant/infrastructure/audio/VoiceCallAudioManager.kt`
+   - `app/src/main/java/com/alian/assistant/infrastructure/audio/AecVoiceCallAudioManager.kt`
+   - `app/src/main/java/com/alian/assistant/infrastructure/ai/tts/HybridTtsClient.kt`
+   - `app/src/main/java/com/alian/assistant/presentation/viewmodel/AlianViewModel.kt`
+   - `app/src/main/java/com/alian/assistant/presentation/ui/overlay/OverlayService.kt`
+
+4. 类型扩展：
+   - `app/src/main/java/com/alian/assistant/infrastructure/ai/asr/AsrTypes.kt`
+   - `app/src/main/java/com/alian/assistant/infrastructure/ai/tts/TtsTypes.kt`
+
+## 6. 验证结果
+
+已执行：
+
+1. `./gradlew :app:compileDebugKotlin` 通过。
+2. `./gradlew :app:testDebugUnitTest` 通过。
+
+## 7. 兼容性说明
+
+1. `cluster` 字段仍保留在配置模型中用于兼容历史数据，但火山 v3 运行时不再依赖它。
+2. 若未填写火山 `App ID / Access Token / Resource ID`，在线火山 ASR/TTS 会明确报“配置不完整”。
+3. 百炼链路保持可用，并支持通过统一引擎路径继续运行。


### PR DESCRIPTION
- 火山 ASR 升级至 v3 大模型流式协议（Header 鉴权 + 二进制协议）
- 火山 TTS 升级至 v3 双向流协议（完整会话生命周期）
- 配置层新增 ASR/TTS Resource ID 支持
- StreamingVoiceRecognitionManager 支持按 speechProvider 动态切换引擎
- HybridTtsClient 在线分支支持百炼/火山动态切换
- AEC 通话链路统一使用外部 PCM 喂流模式